### PR TITLE
Add Signout and Refresh Token

### DIFF
--- a/apps/acqdat_api/lib/acqdat_api_web/auth_pipeline/error_handler.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/auth_pipeline/error_handler.ex
@@ -1,9 +1,10 @@
-defmodule AcqdatWeb.API.ErrorHandler do
+defmodule AcqdatApiWeb.ErrorHandler do
   use AcqdatApiWeb, :controller
 
   def auth_error(conn, {type, _reason}, _opts) do
     conn
-    |> put_status(401)
-    |> render(AcqdatWeb.API.AuthView, "401.json", message: to_string(type))
+    |> put_status(403)
+    |> put_view(AcqdatApiWeb.ErrorView)
+    |> render("403.json", message: to_string(type))
   end
 end

--- a/apps/acqdat_api/lib/acqdat_api_web/controllers/auth_controller.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/controllers/auth_controller.ex
@@ -17,7 +17,7 @@ defmodule AcqdatApiWeb.AuthController do
         send_error(conn, 400, error)
 
       {:login, {:error, message}} ->
-        send_error(conn, 200, message)
+        send_error(conn, 401, message)
     end
   end
 
@@ -34,10 +34,24 @@ defmodule AcqdatApiWeb.AuthController do
         send_error(conn, 400, error)
 
       {:refresh, {:error, message}} ->
-        send_error(conn, 200, message)
+        send_error(conn, 400, message)
     end
   end
 
   def sign_out(conn, params) do
+    changeset = verify_sign_out_params(params)
+
+    with {:extract, {:ok, data}} <- {:extract, extract_changeset_data(changeset)},
+         {:signout, {:ok, message}} <- {:signout, Account.sign_out(data)} do
+      conn
+      |> put_status(200)
+      |> render("signout.json", message: message)
+    else
+      {:extract, {:error, error}} ->
+        send_error(conn, 400, error)
+
+      {:signout, {:error, message}} ->
+        send_error(conn, 400, message)
+    end
   end
 end

--- a/apps/acqdat_api/lib/acqdat_api_web/router.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/router.ex
@@ -22,10 +22,11 @@ defmodule AcqdatApiWeb.Router do
     pipe_through :api
 
     post "/sign-in", AuthController, :sign_in
-    post "/refresh", AuthController, :refresh_token
   end
 
   scope "/", AcqdatApiWeb do
     pipe_through [:api, :api_bearer_auth, :api_ensure_auth]
+    post "/refresh", AuthController, :refresh_token
+    post "/sign-out", AuthController, :sign_out
   end
 end

--- a/apps/acqdat_api/lib/acqdat_api_web/validators/auth.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/validators/auth.ex
@@ -14,6 +14,12 @@ defmodule AcqdatApiWeb.Validators.Auth do
 
   defparams(
     verify_refresh_params(%{
+      refresh_token!: :string
+    })
+  )
+
+  defparams(
+    verify_sign_out_params(%{
       access_token!: :string,
       refresh_token!: :string
     })

--- a/apps/acqdat_api/lib/acqdat_api_web/views/auth_view.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/views/auth_view.ex
@@ -15,6 +15,12 @@ defmodule AcqdatApiWeb.AuthView do
     }
   end
 
+  def render("signout.json", %{message: message}) do
+    %{
+      status: message
+    }
+  end
+
   def render("delete.json", _) do
     %{ok: true}
   end

--- a/apps/acqdat_api/lib/acqdat_api_web/views/error_view.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/views/error_view.ex
@@ -18,6 +18,14 @@ defmodule AcqdatApiWeb.ErrorView do
     handle_assign_error("", assigns)
   end
 
+  def render("401.json", assigns) do
+    :unauthenticated |> err() |> handle_assign_error(assigns)
+  end
+
+  def render("403.json", assigns) do
+    :unauthorized |> err() |> handle_assign_error(assigns)
+  end
+
   def render("400.json", assigns) do
     :bad_request |> err() |> handle_assign_error(assigns)
   end
@@ -42,11 +50,21 @@ defmodule AcqdatApiWeb.ErrorView do
 
   defp has_assign_error_key?(assigns) do
     if Map.has_key?(assigns, :errors) do
-      {:ok, assigns.errors}
+      {:ok, parse_errors(assigns.errors)}
     else
       nil
     end
   end
+
+  defp parse_errors(args) when is_map(args) do
+    if Map.has_key?(args, :__struct__) do
+      Map.from_struct(args)
+    else
+      args
+    end
+  end
+
+  defp parse_errors(args), do: args
 
   defp err(message) do
     case message do

--- a/apps/acqdat_api/test/acqdat_api_web/views/error_view_test.exs
+++ b/apps/acqdat_api/test/acqdat_api_web/views/error_view_test.exs
@@ -5,11 +5,11 @@ defmodule AcqdatApiWeb.ErrorViewTest do
   import Phoenix.View
 
   test "renders 404.json" do
-    assert render(AcqdatApiWeb.ErrorView, "404.json", []) == %{errors: %{detail: "Not Found"}}
+    assert render(AcqdatApiWeb.ErrorView, "404.json", []) == %{errors: %{message: "Not Found"}}
   end
 
   test "renders 500.json" do
     assert render(AcqdatApiWeb.ErrorView, "500.json", []) ==
-             %{errors: %{detail: "Internal Server Error"}}
+             %{errors: %{message: "Server Error"}}
   end
 end

--- a/apps/acqdat_core/test/domain/account_test.exs
+++ b/apps/acqdat_core/test/domain/account_test.exs
@@ -1,18 +1,17 @@
 defmodule AcqdatCore.Domain.AccountTest do
   use ExUnit.Case, async: true
   use AcqdatCore.DataCase
+  import AcqdatCore.Support.Factory
   alias AcqdatCore.Model.User
   alias AcqdatCore.Domain.Account
 
   describe "authenticate/2" do
     setup do
-      params = %{
-        first_name: "Tony",
-        last_name: "Stark",
-        email: "tony@starkindustries.com",
-        password: "stark1234",
-        password_confirmation: "stark1234"
-      }
+      params =
+        build(:user)
+        |> Map.put(:password, "stark1234")
+        |> Map.put(:password_confirmation, "stark1234")
+        |> Map.from_struct()
 
       {:ok, user} = User.create(params)
       [user: user, user_params: params]


### PR DESCRIPTION
Add remaining features to complete authentication which involved
adding refresh token feature and sign out.
Remove minor bugs in guardian error handler.