### PR TITLE
Sensor type Index API

### DIFF
--- a/apps/acqdat_api/lib/acqdat_api_web/router.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/router.ex
@@ -27,6 +27,6 @@ defmodule AcqdatApiWeb.Router do
     pipe_through [:api, :api_bearer_auth, :api_ensure_auth]
     post "/refresh", AuthController, :refresh_token
     post "/sign-out", AuthController, :sign_out
-    resources "/sensor_type", SensorTypeController, only: [:create, :update, :delete]
+    resources "/sensor_type", SensorTypeController, only: [:create, :update, :delete, :index]
   end
 end

--- a/apps/acqdat_api/lib/acqdat_api_web/validators/sensor_type.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/validators/sensor_type.ex
@@ -14,4 +14,11 @@ defmodule AcqdatApiWeb.Validators.SensorType do
       visualizer: :string
     })
   )
+
+  defparams(
+    verify_index_params(%{
+      page_size: :integer,
+      page_number: :integer
+    })
+  )
 end

--- a/apps/acqdat_api/lib/acqdat_api_web/views/sensor_type_view.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/views/sensor_type_view.ex
@@ -1,13 +1,24 @@
 defmodule AcqdatApiWeb.SensorTypeView do
   use AcqdatApiWeb, :view
   alias AcqdatApiWeb.ErrorView
+  alias AcqdatApiWeb.SensorTypeView
 
-  def render("sensor_type.json", manifest) do
+  def render("sensor_type.json", %{sensor_type: sensor_type}) do
     %{
-      id: manifest.id,
-      name: manifest.name,
-      make: manifest.make,
-      identifier: manifest.identifier
+      id: sensor_type.id,
+      name: sensor_type.name,
+      make: sensor_type.make,
+      identifier: sensor_type.identifier
+    }
+  end
+
+  def render("index.json", sensor_types) do
+    %{
+      sensor_types: render_many(sensor_types.entries, SensorTypeView, "sensor_type.json"),
+      page_number: sensor_types.page_number,
+      page_size: sensor_types.page_size,
+      total_entries: sensor_types.total_entries,
+      total_pages: sensor_types.total_pages
     }
   end
 

--- a/apps/acqdat_api/test/acqdat_api_web/views/error_view_test.exs
+++ b/apps/acqdat_api/test/acqdat_api_web/views/error_view_test.exs
@@ -9,7 +9,6 @@ defmodule AcqdatApiWeb.ErrorViewTest do
   end
 
   test "renders 500.json" do
-    assert render(AcqdatApiWeb.ErrorView, "500.json", []) ==
-             %{errors: %{message: "Server Error"}}
+    assert render(AcqdatApiWeb.ErrorView, "500.json", []) == %{errors: %{message: "Server Error"}}
   end
 end

--- a/apps/acqdat_core/lib/acqdat_core/model/sensor_type.ex
+++ b/apps/acqdat_core/lib/acqdat_core/model/sensor_type.ex
@@ -20,6 +20,10 @@ defmodule AcqdatCore.Model.SensorType do
     Repo.all(SensorType)
   end
 
+  def get_all(%{page_size: page_size, page_number: page_number}) do
+    SensorType |> order_by(:id) |> Repo.paginate(page: page_number, page_size: page_size)
+  end
+
   def get(id) when is_integer(id) do
     case Repo.get(SensorType, id) do
       nil ->

--- a/apps/acqdat_core/lib/acqdat_core/repo.ex
+++ b/apps/acqdat_core/lib/acqdat_core/repo.ex
@@ -2,4 +2,6 @@ defmodule AcqdatCore.Repo do
   use Ecto.Repo,
     otp_app: :acqdat_core,
     adapter: Ecto.Adapters.Postgres
+
+  use Scrivener, page_size: 10
 end

--- a/apps/acqdat_core/mix.exs
+++ b/apps/acqdat_core/mix.exs
@@ -33,7 +33,7 @@ defmodule AcqdatCore.MixProject do
   def application do
     [
       mod: {AcqdatCore.Application, []},
-      extra_applications: [:logger]
+      extra_applications: [:logger, :scrivener_ecto]
     ]
   end
 
@@ -50,6 +50,9 @@ defmodule AcqdatCore.MixProject do
       # auth
       {:comeonin, "~> 4.1.1"},
       {:argon2_elixir, "~> 1.2"},
+
+      # Pagination
+      {:scrivener_ecto, "~> 2.0"},
 
       # testing
       {:ex_machina, "~> 2.3"},

--- a/mix.lock
+++ b/mix.lock
@@ -50,6 +50,8 @@
   "poolboy": {:hex, :poolboy, "1.5.2", "392b007a1693a64540cead79830443abf5762f5d30cf50bc95cb2c1aaafa006b", [:rebar3], [], "hexpm"},
   "postgrex": {:hex, :postgrex, "0.15.1", "23ce3417de70f4c0e9e7419ad85bdabcc6860a6925fe2c6f3b1b5b1e8e47bf2f", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 2.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.5", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm"},
+  "scrivener": {:hex, :scrivener, "2.7.0", "fa94cdea21fad0649921d8066b1833d18d296217bfdf4a5389a2f45ee857b773", [:mix], [], "hexpm"},
+  "scrivener_ecto": {:hex, :scrivener_ecto, "2.2.0", "53d5f1ba28f35f17891cf526ee102f8f225b7024d1cdaf8984875467158c9c5e", [:mix], [{:ecto, "~> 3.0", [hex: :ecto, repo: "hexpm", optional: false]}, {:scrivener, "~> 2.4", [hex: :scrivener, repo: "hexpm", optional: false]}], "hexpm"},
   "sobelow": {:hex, :sobelow, "0.8.0", "a3ec73e546dfde19f14818e5000c418e3f305d9edb070e79dd391de0ae1cd1ea", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm"},
   "sweet_xml": {:hex, :sweet_xml, "0.6.6", "fc3e91ec5dd7c787b6195757fbcf0abc670cee1e4172687b45183032221b66b8", [:mix], [], "hexpm"},


### PR DESCRIPTION
-> Why
    * Endpoints are required to Create Update Delete and List Sensor Types. Authentication to access these endpoints is also required.
-> Changes
    * Added sensor type index API