### PR TITLE
Feature/timescale integration

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -17,7 +17,7 @@ jobs:
 
     services: 
       db:
-        image: postgres:11
+        image: timescale/timescaledb:latest-pg11
         ports: 
           - 5432:5432
         env:

--- a/apps/acqdat_core/lib/acqdat_core/model/gateway_data.ex
+++ b/apps/acqdat_core/lib/acqdat_core/model/gateway_data.ex
@@ -1,0 +1,16 @@
+defmodule AcqdatCore.Model.GatewayData do
+  @moduledoc """
+  The Module exposes helper functions to interact with gateway_data
+  data.
+  """
+  import Ecto.Query
+  alias AcqdatCore.Schema.GatewayData
+  alias AcqdatCore.Repo
+
+  # TODO:: Need to add differenet actions for all the read queries from timescale, as per the future requirements
+
+  def create(params) do
+    changeset = GatewayData.changeset(%GatewayData{}, params)
+    Repo.insert(changeset)
+  end
+end

--- a/apps/acqdat_core/lib/acqdat_core/model/sensor_data.ex
+++ b/apps/acqdat_core/lib/acqdat_core/model/sensor_data.ex
@@ -4,30 +4,37 @@ defmodule AcqdatCore.Model.SensorData do
   data.
   """
   import Ecto.Query
-  alias AcqdatCore.Schema.SensorData
+  alias AcqdatCore.Schema.SensorsData
   alias AcqdatCore.Repo
 
   @doc """
   Returns `query` for getting sensor data by `start_time` and `end_time`.
   """
-  def get_by_time_range(start_time, end_time) do
-    from(
-      data in SensorData,
-      where: data.inserted_at >= ^start_time and data.inserted_at <= ^end_time,
-      preload: [sensor: :device]
-    )
-  end
 
-  def time_data_by_sensor(start_time, end_time, sensor_id) do
-    query =
-      from(
-        data in SensorData,
-        where:
-          data.inserted_at >= ^start_time and data.inserted_at <= ^end_time and
-            data.sensor_id == ^sensor_id,
-        select: data
-      )
+  # TODO:: Need to add all the read queries from timescale, as per the future requirements
+  # def get_by_time_range(start_time, end_time) do
+  #   from(
+  #     data in SensorData,
+  #     where: data.inserted_at >= ^start_time and data.inserted_at <= ^end_time,
+  #     preload: [sensor: :device]
+  #   )
+  # end
 
-    Repo.all(query)
+  # def time_data_by_sensor(start_time, end_time, sensor_id) do
+  #   query =
+  #     from(
+  #       data in SensorData,
+  #       where:
+  #         data.inserted_at >= ^start_time and data.inserted_at <= ^end_time and
+  #           data.sensor_id == ^sensor_id,
+  #       select: data
+  #     )
+
+  #   Repo.all(query)
+  # end
+
+  def create(params) do
+    changeset = SensorsData.changeset(%SensorsData{}, params)
+    Repo.insert(changeset)
   end
 end

--- a/apps/acqdat_core/lib/acqdat_core/schema/gateway.ex
+++ b/apps/acqdat_core/lib/acqdat_core/schema/gateway.ex
@@ -27,12 +27,6 @@ defmodule AcqdatCore.Schema.Gateway do
     field(:access_token, :string, null: false)
     field(:serializer, :map)
 
-    embeds_many :parameters, Parameters do
-      field(:name, :string, null: false)
-      field(:uuid, :string, null: false)
-      field(:data_type, :string, null: false)
-    end
-
     # field(:image_url, :string)
     # field(:image, :any, virtual: true)
 
@@ -42,7 +36,8 @@ defmodule AcqdatCore.Schema.Gateway do
   end
 
   @required_params ~w(access_token slug uuid org_id)a
-  @optional_params ~w(name parent_type description parent_id parameters serializer)a
+  @optional_params ~w(name parent_type description parent_id serializer)a
+  @embedded_required_params ~w(name uuid data_type value)a
 
   @permitted @required_params ++ @optional_params
 
@@ -68,7 +63,6 @@ defmodule AcqdatCore.Schema.Gateway do
 
   def common_changeset(changeset) do
     changeset
-    |> cast_embed(:parameters, with: &parameters_changeset/2)
     |> assoc_constraint(:org)
     |> unique_constraint(:slug, name: :acqdat_gateway_slug_index)
     |> unique_constraint(:uuid, name: :acqdat_gateway_uuid_index)

--- a/apps/acqdat_core/lib/acqdat_core/schema/gateway_data.ex
+++ b/apps/acqdat_core/lib/acqdat_core/schema/gateway_data.ex
@@ -28,8 +28,8 @@ defmodule AcqdatCore.Schema.GatewayData do
     end
 
     # associations
-    belongs_to(:gateway, Gateway, on_replace: :delete, primary_key: true)
-    belongs_to(:org, Organisation, on_replace: :delete, primary_key: true)
+    belongs_to(:gateway, Gateway, on_replace: :raise, primary_key: true)
+    belongs_to(:org, Organisation, on_replace: :raise, primary_key: true)
 
     timestamps(type: :utc_datetime, updated_at: false)
   end

--- a/apps/acqdat_core/lib/acqdat_core/schema/gateway_data.ex
+++ b/apps/acqdat_core/lib/acqdat_core/schema/gateway_data.ex
@@ -1,0 +1,64 @@
+defmodule AcqdatCore.Schema.GatewayData do
+  @moduledoc """
+  Models the schema where timeseries related data is stored
+  for all the gateway.
+
+  Each row in this table corresponds to a gateway value at
+  a particular time, for a particular organisation.
+  """
+
+  use AcqdatCore.Schema
+  alias AcqdatCore.Schema.{Gateway, Organisation}
+
+  @typedoc """
+  `inserted_timestamp`: The timestamp sent by device sending the gateway data.
+  `parameters`: The different parameters of the gateway.
+  """
+  @type t :: %__MODULE__{}
+
+  @primary_key false
+  schema("acqdat_gateway_data") do
+    field(:inserted_timestamp, :utc_datetime, primary_key: true)
+
+    embeds_one :parameters, Parameters do
+      field(:name, :string, null: false)
+      field(:uuid, :string, null: false)
+      field(:data_type, :string, null: false)
+      field(:value, :string, null: false)
+    end
+
+    # associations
+    belongs_to(:gateway, Gateway, on_replace: :delete, primary_key: true)
+    belongs_to(:org, Organisation, on_replace: :delete, primary_key: true)
+
+    timestamps(type: :utc_datetime, updated_at: false)
+  end
+
+  @required_params ~w(inserted_timestamp gateway_id org_id)a
+  @embedded_required_params ~w(name uuid data_type value)a
+
+  @spec changeset(
+          __MODULE__.t(),
+          map
+        ) :: Ecto.Changeset.t()
+  def changeset(%__MODULE__{} = gateway_data, params) do
+    gateway_data
+    |> cast(params, @required_params)
+    |> cast_embed(:parameters, with: &parameters_changeset/2)
+    |> validate_required(@required_params)
+    |> assoc_constraint(:gateway)
+    |> assoc_constraint(:org)
+  end
+
+  defp parameters_changeset(schema, params) do
+    schema
+    |> cast(params, @embedded_required_params)
+    |> add_uuid()
+    |> validate_required(@embedded_required_params)
+  end
+
+  defp add_uuid(%Ecto.Changeset{valid?: true} = changeset) do
+    changeset
+    |> put_change(:uuid, UUID.uuid1(:hex))
+  end
+end

--- a/apps/acqdat_core/lib/acqdat_core/schema/sensors_data.ex
+++ b/apps/acqdat_core/lib/acqdat_core/schema/sensors_data.ex
@@ -1,0 +1,64 @@
+defmodule AcqdatCore.Schema.SensorsData do
+  @moduledoc """
+  Models the schema where timeseries related data is stored
+  for all the sensors.
+
+  Each row in this table corresponds to a sensor value at
+  a particular time, for a particular organisation.
+  """
+
+  use AcqdatCore.Schema
+  alias AcqdatCore.Schema.{Sensor, Organisation}
+
+  @typedoc """
+  `inserted_timestamp`: The timestamp sent by device sending the sensor data.
+  `parameters`: The different parameters of the sensor.
+  """
+  @type t :: %__MODULE__{}
+
+  @primary_key false
+  schema("acqdat_sensors_data") do
+    field(:inserted_timestamp, :utc_datetime, primary_key: true)
+
+    embeds_many :parameters, Parameters do
+      field(:name, :string, null: false)
+      field(:uuid, :string, null: false)
+      field(:data_type, :string, null: false)
+      field(:value, :string, null: false)
+    end
+
+    # associations
+    belongs_to(:sensor, Sensor, on_replace: :delete, primary_key: true)
+    belongs_to(:org, Organisation, on_replace: :delete, primary_key: true)
+
+    timestamps(type: :utc_datetime, updated_at: false)
+  end
+
+  @required_params ~w(inserted_timestamp sensor_id org_id)a
+  @embedded_required_params ~w(name uuid data_type value)a
+
+  @spec changeset(
+          __MODULE__.t(),
+          map
+        ) :: Ecto.Changeset.t()
+  def changeset(%__MODULE__{} = sensor_data, params) do
+    sensor_data
+    |> cast(params, @required_params)
+    |> cast_embed(:parameters, with: &parameters_changeset/2)
+    |> validate_required(@required_params)
+    |> assoc_constraint(:sensor)
+    |> assoc_constraint(:org)
+  end
+
+  defp parameters_changeset(schema, params) do
+    schema
+    |> cast(params, @embedded_required_params)
+    |> add_uuid()
+    |> validate_required(@embedded_required_params)
+  end
+
+  defp add_uuid(%Ecto.Changeset{valid?: true} = changeset) do
+    changeset
+    |> put_change(:uuid, UUID.uuid1(:hex))
+  end
+end

--- a/apps/acqdat_core/lib/acqdat_core/schema/sensors_data.ex
+++ b/apps/acqdat_core/lib/acqdat_core/schema/sensors_data.ex
@@ -28,8 +28,8 @@ defmodule AcqdatCore.Schema.SensorsData do
     end
 
     # associations
-    belongs_to(:sensor, Sensor, on_replace: :delete, primary_key: true)
-    belongs_to(:org, Organisation, on_replace: :delete, primary_key: true)
+    belongs_to(:sensor, Sensor, on_replace: :raise, primary_key: true)
+    belongs_to(:org, Organisation, on_replace: :raise, primary_key: true)
 
     timestamps(type: :utc_datetime, updated_at: false)
   end

--- a/apps/acqdat_core/priv/repo/migrations/20200413084047_enable_timescale_extensions.exs
+++ b/apps/acqdat_core/priv/repo/migrations/20200413084047_enable_timescale_extensions.exs
@@ -1,0 +1,11 @@
+defmodule AcqdatCore.Repo.Migrations.EnableTimescaleExtensions do
+  use Ecto.Migration
+
+  def up do
+    execute("CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE")
+  end
+
+  def down do
+    execute("DROP EXTENSION IF EXISTS timescaledb CASCADE")
+  end
+end

--- a/apps/acqdat_core/priv/repo/migrations/20200413084047_enable_timescale_extensions.exs
+++ b/apps/acqdat_core/priv/repo/migrations/20200413084047_enable_timescale_extensions.exs
@@ -2,6 +2,7 @@ defmodule AcqdatCore.Repo.Migrations.EnableTimescaleExtensions do
   use Ecto.Migration
 
   def up do
+    # INFO:: Before running this migration, we need to setup timescale db: Please follow this https://docs.timescale.com/latest/getting-started/installation
     execute("CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE")
   end
 

--- a/apps/acqdat_core/priv/repo/migrations/20200413175306_create_sensor_data_table.exs
+++ b/apps/acqdat_core/priv/repo/migrations/20200413175306_create_sensor_data_table.exs
@@ -6,12 +6,12 @@ defmodule AcqdatCore.Repo.Migrations.CreateSensorDataTable do
     create table(:acqdat_sensors_data, primary_key: false) do
       add(:inserted_timestamp, :timestamptz, null: false, primary_key: true)
 
-      add(:org_id, references("acqdat_organisation", on_delete: :delete_all),
+      add(:org_id, references("acqdat_organisation", on_delete: :raise),
         null: false,
         primary_key: true
       )
 
-      add(:sensor_id, references("acqdat_sensors", on_delete: :delete_all),
+      add(:sensor_id, references("acqdat_sensors", on_delete: :raise),
         null: false,
         primary_key: true
       )

--- a/apps/acqdat_core/priv/repo/migrations/20200413175306_create_sensor_data_table.exs
+++ b/apps/acqdat_core/priv/repo/migrations/20200413175306_create_sensor_data_table.exs
@@ -6,12 +6,12 @@ defmodule AcqdatCore.Repo.Migrations.CreateSensorDataTable do
     create table(:acqdat_sensors_data, primary_key: false) do
       add(:inserted_timestamp, :timestamptz, null: false, primary_key: true)
 
-      add(:org_id, references("acqdat_organisation", on_delete: :raise),
+      add(:org_id, references("acqdat_organisation", on_delete: :restrict),
         null: false,
         primary_key: true
       )
 
-      add(:sensor_id, references("acqdat_sensors", on_delete: :raise),
+      add(:sensor_id, references("acqdat_sensors", on_delete: :restrict),
         null: false,
         primary_key: true
       )

--- a/apps/acqdat_core/priv/repo/migrations/20200413175306_create_sensor_data_table.exs
+++ b/apps/acqdat_core/priv/repo/migrations/20200413175306_create_sensor_data_table.exs
@@ -1,0 +1,34 @@
+defmodule AcqdatCore.Repo.Migrations.CreateSensorDataTable do
+  use Ecto.Migration
+
+  def up do
+    # Create SensorsData Table to store timeseries related data
+    create table(:acqdat_sensors_data, primary_key: false) do
+      add(:inserted_timestamp, :timestamptz, null: false, primary_key: true)
+
+      add(:org_id, references("acqdat_organisation", on_delete: :delete_all),
+        null: false,
+        primary_key: true
+      )
+
+      add(:sensor_id, references("acqdat_sensors", on_delete: :delete_all),
+        null: false,
+        primary_key: true
+      )
+
+      add(:parameters, {:array, :map})
+      timestamps(type: :timestamptz, updated_at: false)
+    end
+
+    create(unique_index(:acqdat_sensors_data, [:inserted_timestamp, :org_id, :sensor_id]))
+    flush()
+    # Convert above created SensorsData Table to HyperTable to incorporate timeseries data
+    # TODO: Need to think, if we can use time_partitioning_func for the chunk partioning, on the basis of (inserted_timestamp + org_id + sensor_id)
+    execute("SELECT create_hypertable('acqdat_sensors_data', 'inserted_timestamp')")
+  end
+
+  def down do
+    drop(index(:acqdat_sensors_data, [:inserted_timestamp, :org_id, :sensor_id]))
+    drop(table(:acqdat_sensors_data))
+  end
+end

--- a/apps/acqdat_core/priv/repo/migrations/20200414051417_create_gateway_data_table.exs
+++ b/apps/acqdat_core/priv/repo/migrations/20200414051417_create_gateway_data_table.exs
@@ -1,0 +1,34 @@
+defmodule AcqdatCore.Repo.Migrations.CreateGatewayDataTable do
+  use Ecto.Migration
+
+  def up do
+    # Create GatewayData Table to store timeseries related data of gateway
+    create table(:acqdat_gateway_data, primary_key: false) do
+      add(:inserted_timestamp, :timestamptz, null: false, primary_key: true)
+
+      add(:org_id, references("acqdat_organisation", on_delete: :delete_all),
+        null: false,
+        primary_key: true
+      )
+
+      add(:gateway_id, references("acqdat_gateway", on_delete: :delete_all),
+        null: false,
+        primary_key: true
+      )
+
+      add(:parameters, :map)
+      timestamps(type: :timestamptz, updated_at: false)
+    end
+
+    create(unique_index(:acqdat_gateway_data, [:inserted_timestamp, :org_id, :gateway_id]))
+    flush()
+    # Convert above created GatewayData Table to HyperTable to incorporate timeseries data
+    # TODO: Need to think, if we can use time_partitioning_func for the chunk partioning, on the basis of (inserted_timestamp + org_id + gateway_id)
+    execute("SELECT create_hypertable('acqdat_gateway_data', 'inserted_timestamp')")
+  end
+
+  def down do
+    drop(index(:acqdat_gateway_data, [:inserted_timestamp, :org_id, :gateway_id]))
+    drop(table(:acqdat_gateway_data))
+  end
+end

--- a/apps/acqdat_core/priv/repo/migrations/20200414051417_create_gateway_data_table.exs
+++ b/apps/acqdat_core/priv/repo/migrations/20200414051417_create_gateway_data_table.exs
@@ -6,12 +6,12 @@ defmodule AcqdatCore.Repo.Migrations.CreateGatewayDataTable do
     create table(:acqdat_gateway_data, primary_key: false) do
       add(:inserted_timestamp, :timestamptz, null: false, primary_key: true)
 
-      add(:org_id, references("acqdat_organisation", on_delete: :raise),
+      add(:org_id, references("acqdat_organisation", on_delete: :restrict),
         null: false,
         primary_key: true
       )
 
-      add(:gateway_id, references("acqdat_gateway", on_delete: :raise),
+      add(:gateway_id, references("acqdat_gateway", on_delete: :restrict),
         null: false,
         primary_key: true
       )

--- a/apps/acqdat_core/priv/repo/migrations/20200414051417_create_gateway_data_table.exs
+++ b/apps/acqdat_core/priv/repo/migrations/20200414051417_create_gateway_data_table.exs
@@ -6,12 +6,12 @@ defmodule AcqdatCore.Repo.Migrations.CreateGatewayDataTable do
     create table(:acqdat_gateway_data, primary_key: false) do
       add(:inserted_timestamp, :timestamptz, null: false, primary_key: true)
 
-      add(:org_id, references("acqdat_organisation", on_delete: :delete_all),
+      add(:org_id, references("acqdat_organisation", on_delete: :raise),
         null: false,
         primary_key: true
       )
 
-      add(:gateway_id, references("acqdat_gateway", on_delete: :delete_all),
+      add(:gateway_id, references("acqdat_gateway", on_delete: :raise),
         null: false,
         primary_key: true
       )

--- a/apps/acqdat_core/test/schema/gateway_data_test.ex
+++ b/apps/acqdat_core/test/schema/gateway_data_test.ex
@@ -1,0 +1,76 @@
+defmodule AcqdatCore.Schema.GatewayDataTest do
+  use ExUnit.Case, async: true
+  use AcqdatCore.DataCase
+  import AcqdatCore.Support.Factory
+
+  alias AcqdatCore.Schema.GatewayData
+
+  describe "changeset/2" do
+    setup do
+      gateway = insert(:gateway)
+
+      [gateway: gateway]
+    end
+
+    test "returns a valid changeset and makes insert", context do
+      %{gateway: gateway} = context
+
+      params = %{
+        parameters: %{data_type: "string", name: "Voltage", value: "456"},
+        inserted_timestamp: DateTime.utc_now(),
+        gateway_id: gateway.id,
+        org_id: gateway.org_id
+      }
+
+      %{valid?: validity} = changeset = GatewayData.changeset(%GatewayData{}, params)
+      assert validity
+
+      assert {:ok, data} = Repo.insert(changeset)
+    end
+
+    test "fails if inserted_timestamp is not present", context do
+      %{gateway: gateway} = context
+
+      params = %{
+        parameters: %{data_type: "string", name: "Voltage", value: "456"},
+        gateway_id: gateway.id,
+        org_id: gateway.org_id
+      }
+
+      %{valid?: validity} = changeset = GatewayData.changeset(%GatewayData{}, params)
+      refute validity
+
+      assert %{inserted_timestamp: ["can't be blank"]} = errors_on(changeset)
+    end
+
+    test "fails if organisation not present", context do
+      %{gateway: gateway} = context
+
+      params = %{
+        parameters: %{data_type: "string", name: "Voltage", value: "456"},
+        inserted_timestamp: DateTime.utc_now(),
+        gateway_id: gateway.id
+      }
+
+      %{valid?: validity} = changeset = GatewayData.changeset(%GatewayData{}, params)
+      refute validity
+
+      assert %{org_id: ["can't be blank"]} = errors_on(changeset)
+    end
+
+    test "fails if gateway not present", context do
+      %{gateway: gateway} = context
+
+      params = %{
+        parameters: %{data_type: "string", name: "Voltage", value: "456"},
+        inserted_timestamp: DateTime.utc_now(),
+        org_id: gateway.org_id
+      }
+
+      %{valid?: validity} = changeset = GatewayData.changeset(%GatewayData{}, params)
+      refute validity
+
+      assert %{gateway_id: ["can't be blank"]} = errors_on(changeset)
+    end
+  end
+end

--- a/apps/acqdat_core/test/support/factory/factory.ex
+++ b/apps/acqdat_core/test/support/factory/factory.ex
@@ -22,7 +22,8 @@ defmodule AcqdatCore.Support.Factory do
     Sensor,
     DigitalTwin,
     Organisation,
-    Asset
+    Asset,
+    Gateway
   }
 
   alias AcqdatCore.Schema.ToolManagement.{
@@ -81,6 +82,16 @@ defmodule AcqdatCore.Support.Factory do
       uuid: UUID.uuid1(:hex),
       name: sequence(:sensor_name, &"Sensor#{&1}"),
       slug: sequence(:sensor_name, &"Sensor#{&1}"),
+      org: build(:organisation)
+    }
+  end
+
+  def gateway_factory() do
+    %Gateway{
+      uuid: UUID.uuid1(:hex),
+      name: sequence(:gateway_name, &"Gateway#{&1}"),
+      access_token: sequence(:gateway_name, &"Gateway#{&1}"),
+      slug: sequence(:gateway_name, &"Gateway#{&1}"),
       org: build(:organisation)
     }
   end


### PR DESCRIPTION
**Why ?**

In order to store time-series data, we need TimescaleDB integration. It is nothing, but extension on PostgreSQL.
For full details, please refer this: [https://docs.timescale.com/latest/introduction](https://docs.timescale.com/latest/introduction)

**Relations**

We currently have two tables(Sensors and Gateways), which requires time-series data incorporation.

- for Sensors, we will have SensorsData Table(HyperTable), which will store its time-series data
- for Gateways, we will have GatewayData Table(HyperTable), which will store its time-series data

**Changes**

- Added Migration To Add timescaledb extension on PostgreSQL databases
- Added Migration To create sensors_data table
- Made sensors_data table as hypertable
- Added Migration To create gateway_data table
- Made gateway_data table as hypertable
- Added Schemas for SensorsData and GatewayTable

**Note:** TimescaleDB integration will not work for PostgreSQL version 12, as currently support for it is still in development phase
