### PR TITLE
Add API to validate access token

### DIFF
--- a/apps/acqdat_api/lib/acqdat_api_web/controllers/auth_controller.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/controllers/auth_controller.ex
@@ -21,14 +21,16 @@ defmodule AcqdatApiWeb.AuthController do
     end
   end
 
-  def refresh_token(conn, params) do
+  def validate_token(conn, params) do
     changeset = verify_refresh_params(params)
+    refresh_token = AcqdatApiWeb.Guardian.Plug.current_token(conn)
 
     with {:extract, {:ok, data}} <- {:extract, extract_changeset_data(changeset)},
-         {:refresh, {:ok, result}} <- {:refresh, Account.refresh_token(data)} do
+         {:refresh, {:ok, result}} <-
+           {:refresh, Account.validate_token(Map.put(data, :refresh_token, refresh_token))} do
       conn
       |> put_status(200)
-      |> render("refresh.json", token: result)
+      |> render("validate_token.json", token: result)
     else
       {:extract, {:error, error}} ->
         send_error(conn, 400, error)

--- a/apps/acqdat_api/lib/acqdat_api_web/router.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/router.ex
@@ -25,7 +25,7 @@ defmodule AcqdatApiWeb.Router do
 
   scope "/", AcqdatApiWeb do
     pipe_through [:api, :api_bearer_auth, :api_ensure_auth]
-    post "/refresh", AuthController, :refresh_token
+    post "/validate-token", AuthController, :validate_token
     post "/sign-out", AuthController, :sign_out
     resources "/org", OrganisationController, only: [:show]
 

--- a/apps/acqdat_api/lib/acqdat_api_web/validators/auth.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/validators/auth.ex
@@ -14,7 +14,7 @@ defmodule AcqdatApiWeb.Validators.Auth do
 
   defparams(
     verify_refresh_params(%{
-      refresh_token!: :string
+      access_token!: :string
     })
   )
 

--- a/apps/acqdat_api/lib/acqdat_api_web/views/auth_view.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/views/auth_view.ex
@@ -9,8 +9,9 @@ defmodule AcqdatApiWeb.AuthView do
     }
   end
 
-  def render("refresh.json", manifest) do
+  def render("validate_token.json", manifest) do
     %{
+      message: "Authorized",
       access_token: manifest.token
     }
   end


### PR DESCRIPTION
## Why?
APIs are accessed with access tokens however, access tokens are expired frequently. They need to be validated and renewed with a refresh token over a certain time period.

## Changes
- Add API to validate access tokens
- Add function to handle token verification
- Add code to handle token renewal with the refresh token