### PR TITLE
Send widget_id in request body

### DIFF
--- a/apps/acqdat_api/lib/acqdat_api_web/controllers/widgets/user_widget_controller.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/controllers/widgets/user_widget_controller.ex
@@ -73,7 +73,12 @@ defmodule AcqdatApiWeb.Widgets.UserWidgetController do
          %{params: %{"widget_id" => widget_id, "user_id" => user_id}} = conn,
          _params
        ) do
-    {widget_id, _} = Integer.parse(widget_id)
+    widget_id =
+      case String.valid?(widget_id) do
+        false -> widget_id
+        true -> String.to_integer(widget_id)
+      end
+
     {user_id, _} = Integer.parse(user_id)
 
     case WidgetModel.get(widget_id) do


### PR DESCRIPTION
# Why?
The user widget association controller action expects the `widget_id` in request body instead of query params.

## Changes
- Modify plug to `verify_widget_and_user` to include `widget_id`.
- Modify user widget creation POST API. 