### PR TITLE
Add codecov

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Add Build essential
-      run: apt-get update && apt-get install -y git && apt-get install -y make && apt-get -y install build-essential
+      run: apt-get update && apt-get install -y git && apt-get install -y make && apt-get -y install build-essential && apt-get install -y curl
     - name: Install Dependencies
       run: |
         mix local.rebar --force
@@ -37,6 +37,10 @@ jobs:
     - name: Check code formatting
       run: mix format --check-formatted
     - name: Run tests (with coverage)
-      run: mix test --cover
+      run:  mix coveralls.json --umbrella
       env:
         DB_HOST: db
+    - name: Report coverage to Codecov
+      uses: codecov/codecov-action@v1 
+      with: 
+        file: ./cover/excoveralls.json

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# AcqdatUmbrella
+# MADS-IoT-Explorer
 
-**TODO: Add description**
+![Build](https://github.com/DataKrewTech/MADS-IoT-Explorer/workflows/Elixir%20CI/badge.svg)
+[![codecov](https://codecov.io/gh/DataKrewTech/MADS-IoT-Explorer/branch/master/graph/badge.svg)](https://codecov.io/gh/DataKrewTech/MADS-IoT-Explorer)
+
+---------------------
 

--- a/apps/acqdat_api/mix.exs
+++ b/apps/acqdat_api/mix.exs
@@ -13,7 +13,8 @@ defmodule AcqdatApi.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      test_coverage: [tool: ExCoveralls]
     ]
   end
 

--- a/apps/acqdat_iot/mix.exs
+++ b/apps/acqdat_iot/mix.exs
@@ -13,7 +13,8 @@ defmodule AcqdatIot.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      test_coverage: [tool: ExCoveralls]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,8 @@ defmodule AcqdatUmbrella.MixProject do
         coveralls: :test,
         "coveralls.detail": :test,
         "coveralls.post": :test,
-        "coveralls.html": :test
+        "coveralls.html": :test,
+        "coveralls.json": :test
       ],
       dialyzer: [
         plt_file: {:no_warn, "priv/plts/dialyzer.plt"},
@@ -67,7 +68,10 @@ defmodule AcqdatUmbrella.MixProject do
       {:tirexs, "~> 0.8"},
 
       # logger
-      {:gen_retry, "~> 1.2.0"}
+      {:gen_retry, "~> 1.2.0"},
+
+      # testing
+      {:excoveralls, "~> 0.10", only: :test}
     ]
   end
 


### PR DESCRIPTION
# Why?
The CI run should display a code coverage report after running the test. This will allow us to see if the new changes are increasing or decreasing the code coverage. It will also give us a glimpse into the portion of code that still needs thorough testing.

