### PR TITLE
Http command handling

### DIFF
--- a/apps/acqdat_api/lib/acqdat_api/application.ex
+++ b/apps/acqdat_api/lib/acqdat_api/application.ex
@@ -10,6 +10,7 @@ defmodule AcqdatApi.Application do
     children = [
       # Start the endpoint when the application starts
       AcqdatApiWeb.Endpoint,
+      AcqdatApi.AcqdatApi.IotManager.CommandHandler,
       {Task.Supervisor, name: Datakrew.TaskSupervisor}
       # Starts a worker by calling: AcqdatApi.Worker.start_link(arg)
       # {AcqdatApi.Worker, arg},

--- a/apps/acqdat_api/lib/acqdat_api/application.ex
+++ b/apps/acqdat_api/lib/acqdat_api/application.ex
@@ -10,7 +10,7 @@ defmodule AcqdatApi.Application do
     children = [
       # Start the endpoint when the application starts
       AcqdatApiWeb.Endpoint,
-      AcqdatApi.AcqdatApi.IotManager.CommandHandler,
+      AcqdatApi.IotManager.HTTPCommandHandler,
       {Task.Supervisor, name: Datakrew.TaskSupervisor}
       # Starts a worker by calling: AcqdatApi.Worker.start_link(arg)
       # {AcqdatApi.Worker, arg},

--- a/apps/acqdat_api/lib/acqdat_api/iot-manager/command_handler/command_handler.ex
+++ b/apps/acqdat_api/lib/acqdat_api/iot-manager/command_handler/command_handler.ex
@@ -1,0 +1,45 @@
+defmodule AcqdatApi.IotManager.HTTPCommandHandler do
+  @moduledoc """
+  Module to handle commands sent for gateways with channel HTTP.
+
+  Stores commands sent for different gateways in an ets table.
+  The data is used when a config response needs to be sent to the
+  gateway.
+  """
+
+  use GenServer
+
+  def init(arg) do
+    :ets.new(:http_command_storage, [
+      :set,
+      :public,
+      :named_table,
+      {:read_concurrency, true},
+      {:write_concurrency, true}
+    ])
+
+    {:ok, arg}
+  end
+
+  def start_link(arg) do
+    GenServer.start_link(__MODULE__, arg, name: __MODULE__)
+  end
+
+  def get(key) do
+    case :ets.lookup(:http_command_storage, key) do
+      [] ->
+        nil
+
+      [{_key, value}] ->
+        value
+    end
+  end
+
+  def put(key, value) do
+    :ets.insert(:http_command_storage, {key, value})
+  end
+
+  def delete(key) do
+    :ets.delete(:http_command_storage, key)
+  end
+end

--- a/apps/acqdat_api/lib/acqdat_api/iot-manager/gateway.ex
+++ b/apps/acqdat_api/lib/acqdat_api/iot-manager/gateway.ex
@@ -2,6 +2,7 @@ defmodule AcqdatApi.IotManager.Gateway do
   import AcqdatApiWeb.Helpers
   alias AcqdatCore.Repo
   alias AcqdatCore.Model.IotManager.Gateway
+  alias AcqdatApi.IotManager.HTTPCommandHandler
 
   defdelegate get_all(data, preloads), to: Gateway
   defdelegate delete(gateway), to: Gateway
@@ -24,5 +25,14 @@ defmodule AcqdatApi.IotManager.Gateway do
   defp params_extraction(params) do
     Map.from_struct(params)
     |> Map.drop([:_id, :__meta__])
+  end
+
+  def store_data(%{"gateway_id" => gateway_id, "commands" => command}) do
+    HTTPCommandHandler.put(String.to_integer(gateway_id), command)
+  end
+
+  def follow_mqtt_path() do
+    require IEx
+    IEx.pry()
   end
 end

--- a/apps/acqdat_api/lib/acqdat_api/iot-manager/gateway.ex
+++ b/apps/acqdat_api/lib/acqdat_api/iot-manager/gateway.ex
@@ -27,11 +27,12 @@ defmodule AcqdatApi.IotManager.Gateway do
     |> Map.drop([:_id, :__meta__])
   end
 
-  def store_data(%{"gateway_id" => gateway_id, "commands" => command}) do
+  def setup_command(_channel = "http", params) do
+    %{"gateway_id" => gateway_id, "commands" => command} = params
     HTTPCommandHandler.put(String.to_integer(gateway_id), command)
   end
 
-  def follow_mqtt_path() do
+  def setup_command(_channel = "mqtt", params) do
     require IEx
     IEx.pry()
   end

--- a/apps/acqdat_api/lib/acqdat_api_web/controllers/iot-manager/gateway_controller.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/controllers/iot-manager/gateway_controller.ex
@@ -10,7 +10,7 @@ defmodule AcqdatApiWeb.IotManager.GatewayController do
 
   plug AcqdatApiWeb.Plug.LoadOrg
   plug AcqdatApiWeb.Plug.LoadProject
-  plug AcqdatApiWeb.Plug.LoadGateway when action in [:update, :delete, :show]
+  plug AcqdatApiWeb.Plug.LoadGateway when action in [:update, :delete, :show, :store_commands]
   plug :load_hierarchy_tree when action in [:hierarchy]
 
   def index(conn, params) do
@@ -117,6 +117,33 @@ defmodule AcqdatApiWeb.IotManager.GatewayController do
 
             conn
             |> send_error(400, error)
+        end
+
+      404 ->
+        conn
+        |> send_error(404, "Resource Not Found")
+    end
+  end
+
+  def store_commands(conn, params) do
+    case conn.status do
+      nil ->
+        case conn.assigns.gateway.channel do
+          "http" ->
+            case Gateway.store_data(params) do
+              true ->
+                conn
+                |> put_status(200)
+                |> json(%{"data inserted" => true})
+
+              false ->
+                conn
+                |> put_status(400)
+                |> json(%{"data inserted" => false})
+            end
+
+          "mqtt" ->
+            Gateway.follow_mqtt_path()
         end
 
       404 ->

--- a/apps/acqdat_api/lib/acqdat_api_web/controllers/iot-manager/gateway_controller.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/controllers/iot-manager/gateway_controller.ex
@@ -128,24 +128,11 @@ defmodule AcqdatApiWeb.IotManager.GatewayController do
   def store_commands(conn, params) do
     case conn.status do
       nil ->
-        case conn.assigns.gateway.channel do
-          "http" ->
-            case Gateway.store_data(params) do
-              true ->
-                conn
-                |> put_status(200)
-                |> json(%{"data inserted" => true})
-
-              false ->
-                conn
-                |> put_status(400)
-                |> json(%{"data inserted" => false})
-            end
-
-          "mqtt" ->
-            Gateway.follow_mqtt_path()
-        end
-
+        channel = conn.assigns.gateway.channel
+        Gateway.setup_command(channel, params)
+        conn
+        |> put_status(200)
+        |> json(%{"command_set" => true})
       404 ->
         conn
         |> send_error(404, "Resource Not Found")

--- a/apps/acqdat_api/lib/acqdat_api_web/controllers/iot-manager/gateway_controller.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/controllers/iot-manager/gateway_controller.ex
@@ -130,9 +130,11 @@ defmodule AcqdatApiWeb.IotManager.GatewayController do
       nil ->
         channel = conn.assigns.gateway.channel
         Gateway.setup_command(channel, params)
+
         conn
         |> put_status(200)
         |> json(%{"command_set" => true})
+
       404 ->
         conn
         |> send_error(404, "Resource Not Found")

--- a/apps/acqdat_api/lib/acqdat_api_web/router.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/router.ex
@@ -80,6 +80,7 @@ defmodule AcqdatApiWeb.Router do
 
     scope "/projects/:project_id", IotManager do
       resources "/gateways", GatewayController, except: [:new, :edit]
+      post "/gateways/:gateway_id/store_commands", GatewayController, :store_commands
       get("/hierarchy", GatewayController, :hierarchy)
     end
 


### PR DESCRIPTION
# Why?
The HTTP command handling feature will allow a user to send a command to the respective gateway. The commands are stored temporarily in an `ETS` table. Whenever a gateway communicating via HTTP sends data the command would be returned for it.

## Changes
- Adds an ETS table to store command temporarily for a gateway.
- Adds a controller action to set commands for a gateway.