### PR TITLE
FIXES: 500 Internal Server Error While Deleting A Project (Proper Error Message Should Be Shown)

### DIFF
--- a/apps/acqdat_api/lib/acqdat_api_web/controllers/entity-management/project_controller.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/controllers/entity-management/project_controller.ex
@@ -100,7 +100,10 @@ defmodule AcqdatApiWeb.EntityManagement.ProjectController do
         case Project.delete(project) do
           {:ok, project} ->
             project = Map.put(project, :image_url, project.avatar)
-            ImageDeletion.delete_operation(project, "project")
+
+            if project.avatar != nil do
+              ImageDeletion.delete_operation(project, "project")
+            end
 
             conn
             |> put_status(200)

--- a/apps/acqdat_api/test/acqdat_api_web/controllers/entity-management/project_controller_test.exs
+++ b/apps/acqdat_api/test/acqdat_api_web/controllers/entity-management/project_controller_test.exs
@@ -200,6 +200,39 @@ defmodule AcqdatApiWeb.EntityManagement.ProjectControllerTest do
       assert response["id"] == project.id
     end
 
+    test "fails if project has associated asset_types", %{conn: conn} do
+      asset_type = insert(:asset_type)
+
+      conn =
+        delete(conn, Routes.project_path(conn, :delete, asset_type.org_id, asset_type.project_id))
+
+      response = conn |> json_response(400)
+
+      assert response == %{
+               "errors" => %{
+                 "message" => %{"asset_types" => ["asset_types are attached to this project"]}
+               }
+             }
+    end
+
+    test "fails if project has associated sensor_types", %{conn: conn} do
+      sensor_type = insert(:sensor_type)
+
+      conn =
+        delete(
+          conn,
+          Routes.project_path(conn, :delete, sensor_type.org_id, sensor_type.project_id)
+        )
+
+      response = conn |> json_response(400)
+
+      assert response == %{
+               "errors" => %{
+                 "message" => %{"sensor_types" => ["sensor_types are attached to this project"]}
+               }
+             }
+    end
+
     test "fails if invalid token in authorization header", %{conn: conn} do
       project = insert(:project)
       bad_access_token = "qwerty1234567qwerty"

--- a/apps/acqdat_core/lib/acqdat_core/entity-management/model/project.ex
+++ b/apps/acqdat_core/lib/acqdat_core/entity-management/model/project.ex
@@ -82,7 +82,8 @@ defmodule AcqdatCore.Model.EntityManagement.Project do
   end
 
   def delete(project) do
-    case Repo.delete(project) do
+    changeset = Project.delete_changeset(project)
+    case Repo.delete(changeset) do
       {:ok, project} ->
         project = project |> Repo.preload([:leads, :users])
         {:ok, project}

--- a/apps/acqdat_core/lib/acqdat_core/entity-management/model/project.ex
+++ b/apps/acqdat_core/lib/acqdat_core/entity-management/model/project.ex
@@ -83,6 +83,7 @@ defmodule AcqdatCore.Model.EntityManagement.Project do
 
   def delete(project) do
     changeset = Project.delete_changeset(project)
+
     case Repo.delete(changeset) do
       {:ok, project} ->
         project = project |> Repo.preload([:leads, :users])

--- a/apps/acqdat_core/lib/acqdat_core/entity-management/schema/project.ex
+++ b/apps/acqdat_core/lib/acqdat_core/entity-management/schema/project.ex
@@ -77,8 +77,14 @@ defmodule AcqdatCore.Schema.EntityManagement.Project do
   def delete_changeset(%__MODULE__{} = project) do
     project
     |> cast(%{}, [])
-    |> foreign_key_constraint(:asset_types, name: :acqdat_asset_types_project_id_fkey, message: "asset_types are attached to this project")
-    |> foreign_key_constraint(:sensor_types, name: :acqdat_sensor_types_project_id_fkey, message: "sensor_types are attached to this project")
+    |> foreign_key_constraint(:asset_types,
+      name: :acqdat_asset_types_project_id_fkey,
+      message: "asset_types are attached to this project"
+    )
+    |> foreign_key_constraint(:sensor_types,
+      name: :acqdat_sensor_types_project_id_fkey,
+      message: "sensor_types are attached to this project"
+    )
   end
 
   def common_changeset(changeset) do

--- a/apps/acqdat_core/lib/acqdat_core/entity-management/schema/project.ex
+++ b/apps/acqdat_core/lib/acqdat_core/entity-management/schema/project.ex
@@ -74,6 +74,13 @@ defmodule AcqdatCore.Schema.EntityManagement.Project do
     |> put_project_users(params["user_ids"])
   end
 
+  def delete_changeset(%__MODULE__{} = project) do
+    project
+    |> cast(%{}, [])
+    |> foreign_key_constraint(:asset_types, name: :acqdat_asset_types_project_id_fkey, message: "asset_types are attached to this project")
+    |> foreign_key_constraint(:sensor_types, name: :acqdat_sensor_types_project_id_fkey, message: "sensor_types are attached to this project")
+  end
+
   def common_changeset(changeset) do
     changeset
     |> assoc_constraint(:org)

--- a/apps/acqdat_core/test/entity-management/model/project_test.exs
+++ b/apps/acqdat_core/test/entity-management/model/project_test.exs
@@ -50,4 +50,34 @@ defmodule AcqdatCore.Model.EntityManagement.ProjectTest do
       assert length(result) != 0
     end
   end
+
+  describe "delete/1" do
+    test "deletes a particular project" do
+      project = insert(:project)
+
+      {:ok, result} = Project.delete(project)
+
+      assert not is_nil(result)
+      assert result.id == project.id
+    end
+
+    test "will raise error if project have associated asset_types" do
+      asset_type = insert(:asset_type)
+
+      {:ok, project} = Project.get_by_id(asset_type.project_id)
+      {:error, changeset} = Project.delete(project)
+
+      assert %{asset_types: ["asset_types are attached to this project"]} == errors_on(changeset)
+    end
+
+    test "will raise error if project have associated sensor_types" do
+      sensor_type = insert(:sensor_type)
+
+      {:ok, project} = Project.get_by_id(sensor_type.project_id)
+      {:error, changeset} = Project.delete(project)
+
+      assert %{sensor_types: ["sensor_types are attached to this project"]} ==
+               errors_on(changeset)
+    end
+  end
 end


### PR DESCRIPTION
**changes:**
there were two issues during project deletion:

- there was no check for empty project avatar, when we are deleting project's avatar, so made it conditional here

- we need to check, for the project's children like asset_type and sensor_type(they have foreign key[restrict] association with project) while deleting parent(project) 