### PR TITLE
Add support for command widgets

### DIFF
--- a/apps/acqdat_api/lib/acqdat_api/dashboard_management/command_widget.ex
+++ b/apps/acqdat_api/lib/acqdat_api/dashboard_management/command_widget.ex
@@ -1,0 +1,9 @@
+defmodule AcqdatApi.DashboardManagement.CommandWidget do
+  alias AcqdatCore.Model.DashboardManagement.CommandWidget
+
+  defdelegate get_command_widget_types(), to: CommandWidget
+  defdelegate create(params), to: CommandWidget
+  defdelegate update(widget_type, params), to: CommandWidget
+  defdelegate delete(widget_id), to:  CommandWidget
+  defdelegate get(id), to: CommandWidget
+end

--- a/apps/acqdat_api/lib/acqdat_api/dashboard_management/command_widget.ex
+++ b/apps/acqdat_api/lib/acqdat_api/dashboard_management/command_widget.ex
@@ -4,6 +4,6 @@ defmodule AcqdatApi.DashboardManagement.CommandWidget do
   defdelegate get_command_widget_types(), to: CommandWidget
   defdelegate create(params), to: CommandWidget
   defdelegate update(widget_type, params), to: CommandWidget
-  defdelegate delete(widget_id), to:  CommandWidget
+  defdelegate delete(widget_id), to: CommandWidget
   defdelegate get(id), to: CommandWidget
 end

--- a/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/command_widget_controller.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/command_widget_controller.ex
@@ -1,0 +1,24 @@
+defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetController do
+  use AcqdatApiWeb, :controller
+  alias AcqdatApi.DashboardManagement.CommandWidget
+
+  def command_widget_types(conn, _params) do
+
+  end
+
+  def create(conn, params) do
+
+  end
+
+  def update(conn, params) do
+
+  end
+
+  def show(conn, params) do
+
+  end
+
+  def delete(conn, params) do
+
+  end
+end

--- a/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/command_widget_controller.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/command_widget_controller.ex
@@ -9,6 +9,7 @@ defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetController do
 
   def command_widget_types(conn, _params) do
     widget_types = CommandWidget.get_command_widget_types()
+
     conn
     |> put_status(200)
     |> render("command_widget_types.json", command_widget_types: widget_types)
@@ -18,9 +19,10 @@ defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetController do
     case conn.status do
       nil ->
         changeset = verify_params(params)
+
         with {:extract, {:ok, data}} <- {:extract, extract_changeset_data(changeset)},
-          {:create, {:ok, command_widget}} <- {:create,
-            CommandWidget.create(Map.from_struct(data))} do
+             {:create, {:ok, command_widget}} <-
+               {:create, CommandWidget.create(Map.from_struct(data))} do
           conn
           |> put_status(200)
           |> render("show.json", %{command_widget: command_widget})
@@ -31,9 +33,11 @@ defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetController do
           {:create, {:error, %Ecto.Changeset{} = changeset}} ->
             error = extract_changeset_error(changeset)
             send_error(conn, 400, error)
+
           {:create, {:error, error}} ->
             send_error(conn, 400, error)
         end
+
       404 ->
         conn
         |> send_error(404, "Resource Not Found")
@@ -44,19 +48,21 @@ defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetController do
     case conn.status do
       nil ->
         command_widget = conn.assigns.command_widget
-        with {:update, {:ok, command_widget}} <- {:update,
-            CommandWidget.update(command_widget, params)} do
+
+        with {:update, {:ok, command_widget}} <-
+               {:update, CommandWidget.update(command_widget, params)} do
           conn
           |> put_status(200)
           |> render("show.json", %{command_widget: command_widget})
         else
-
           {:update, {:error, %Ecto.Changeset{} = changeset}} ->
             error = extract_changeset_error(changeset)
             send_error(conn, 400, error)
+
           {:update, {:error, error}} ->
             send_error(conn, 400, error)
         end
+
       404 ->
         conn
         |> send_error(404, "Resource Not Found")
@@ -67,9 +73,11 @@ defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetController do
     case conn.status do
       nil ->
         command_widget = conn.assigns.command_widget
-          conn
-          |> put_status(200)
-          |> render("show.json", %{command_widget: command_widget})
+
+        conn
+        |> put_status(200)
+        |> render("show.json", %{command_widget: command_widget})
+
       404 ->
         conn
         |> send_error(404, "Resource Not Found")
@@ -80,6 +88,7 @@ defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetController do
     case conn.status do
       nil ->
         command_widget = conn.assigns.command_widget
+
         with {:ok, command_widget} <- CommandWidget.delete(command_widget) do
           conn
           |> put_status(200)
@@ -88,6 +97,7 @@ defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetController do
           {:error, _message} ->
             send_error(conn, 404, "Can not delete CommandWidget")
         end
+
       404 ->
         conn
         |> send_error(404, "Resource Not Found")

--- a/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/command_widget_controller.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/command_widget_controller.ex
@@ -1,24 +1,96 @@
 defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetController do
   use AcqdatApiWeb, :controller
+  import AcqdatApiWeb.Validators.DashboardManagement.CommandWidget
+  import AcqdatApiWeb.Helpers
   alias AcqdatApi.DashboardManagement.CommandWidget
 
-  def command_widget_types(conn, _params) do
+  plug AcqdatApiWeb.Plug.LoadDashboard when action not in [:command_widget_types]
+  plug AcqdatApiWeb.Plug.CommandWidget when action in [:update, :delete]
 
+  def command_widget_types(conn, _params) do
+    widget_types = CommandWidget.get_command_widget_types()
+    conn
+    |> put_status(200)
+    |> render("command_widget_types.json", command_widget_types: widget_types)
   end
 
   def create(conn, params) do
+    case conn.status do
+      nil ->
+        changeset = verify_params(params)
+        with {:extract, {:ok, data}} <- {:extract, extract_changeset_data(changeset)},
+          {:create, {:ok, command_widget}} <- {:create,
+            CommandWidget.create(Map.from_struct(data))} do
+          conn
+          |> put_status(200)
+          |> render("show.json", %{command_widget: command_widget})
+        else
+          {:extract, {:error, error}} ->
+            send_error(conn, 400, error)
 
+          {:create, {:error, %Ecto.Changeset{} = changeset}} ->
+            error = extract_changeset_error(changeset)
+            send_error(conn, 400, error)
+          {:create, {:error, error}} ->
+            send_error(conn, 400, error)
+        end
+      404 ->
+        conn
+        |> send_error(404, "Resource Not Found")
+    end
   end
 
   def update(conn, params) do
+    case conn.status do
+      nil ->
+        command_widget = conn.assigns.command_widget
+        with {:update, {:ok, command_widget}} <- {:update,
+            CommandWidget.update(command_widget, params)} do
+          conn
+          |> put_status(200)
+          |> render("show.json", %{command_widget: command_widget})
+        else
 
+          {:update, {:error, %Ecto.Changeset{} = changeset}} ->
+            error = extract_changeset_error(changeset)
+            send_error(conn, 400, error)
+          {:update, {:error, error}} ->
+            send_error(conn, 400, error)
+        end
+      404 ->
+        conn
+        |> send_error(404, "Resource Not Found")
+    end
   end
 
-  def show(conn, params) do
-
+  def show(conn, _params) do
+    case conn.status do
+      nil ->
+        command_widget = conn.assigns.command_widget
+          conn
+          |> put_status(200)
+          |> render("show.json", %{command_widget: command_widget})
+      404 ->
+        conn
+        |> send_error(404, "Resource Not Found")
+    end
   end
 
-  def delete(conn, params) do
-
+  def delete(conn, _params) do
+    case conn.status do
+      nil ->
+        command_widget = conn.assigns.command_widget
+        with {:ok, command_widget} <- CommandWidget.delete(command_widget) do
+          conn
+          |> put_status(200)
+          |> render("show.json", %{command_widget: command_widget})
+        else
+          {:error, _message} ->
+            send_error(conn, 404, "Can not delete CommandWidget")
+        end
+      404 ->
+        conn
+        |> send_error(404, "Resource Not Found")
+    end
   end
 end

--- a/apps/acqdat_api/lib/acqdat_api_web/plugs/load_command_widget.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/plugs/load_command_widget.ex
@@ -1,0 +1,29 @@
+defmodule AcqdatApiWeb.Plug.CommandWidget do
+  import Plug.Conn
+  alias AcqdatCore.Model.DashboardManagement.CommandWidget
+
+  @spec init(any) :: any
+  def init(default), do: default
+
+  @spec call(Plug.Conn.t(), any) :: Plug.Conn.t()
+  def call(%{params: %{"command_widget_id" => widget_id}} = conn, _params) do
+    check_widget(conn, widget_id)
+  end
+
+  def call(%{params: %{"id" => widget_id}} = conn, _params) do
+    check_widget(conn, widget_id)
+  end
+
+  defp check_widget(conn, widget_id) do
+    {widget_id, _} = Integer.parse(widget_id)
+
+    case CommandWidget.get(widget_id) do
+      {:ok, command_widget} ->
+        assign(conn, :command_widget, command_widget)
+
+      {:error, _message} ->
+        conn
+        |> put_status(404)
+    end
+  end
+end

--- a/apps/acqdat_api/lib/acqdat_api_web/router.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/router.ex
@@ -105,11 +105,12 @@ defmodule AcqdatApiWeb.Router do
     resources "/dashboards", DashboardManagement.DashboardController, except: [:new, :edit]
 
     scope "/dashboards/:dashboard_id", DashboardManagement do
-      resources "/command_widgets", CommandWidgetController,
-        except: [:new, :index, :edit]
-      end
-    get "/command_widget_types", DashboardManagement.CommandWidgetController,
-      :command_widget_types
+      resources "/command_widgets", CommandWidgetController, except: [:new, :index, :edit]
+    end
+
+    get "/command_widget_types",
+        DashboardManagement.CommandWidgetController,
+        :command_widget_types
 
     post "/dashboards/:dashboard_id/widgets/:widget_id/widget_instances",
          DashboardManagement.WidgetInstanceController,

--- a/apps/acqdat_api/lib/acqdat_api_web/router.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/router.ex
@@ -104,6 +104,12 @@ defmodule AcqdatApiWeb.Router do
 
     resources "/dashboards", DashboardManagement.DashboardController, except: [:new, :edit]
 
+    scope "/dashboards/:dashboard_id", DashboardManagement do
+      resources "/command_widgets", CommandWidgetController,
+        except: [:new, :index, :edit]
+      get "/command_widget_types", CommandWidgetController, :command_widget_types
+    end
+
     post "/dashboards/:dashboard_id/widgets/:widget_id/widget_instances",
          DashboardManagement.WidgetInstanceController,
          :create,

--- a/apps/acqdat_api/lib/acqdat_api_web/router.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/router.ex
@@ -107,8 +107,9 @@ defmodule AcqdatApiWeb.Router do
     scope "/dashboards/:dashboard_id", DashboardManagement do
       resources "/command_widgets", CommandWidgetController,
         except: [:new, :index, :edit]
-      get "/command_widget_types", CommandWidgetController, :command_widget_types
-    end
+      end
+    get "/command_widget_types", DashboardManagement.CommandWidgetController,
+      :command_widget_types
 
     post "/dashboards/:dashboard_id/widgets/:widget_id/widget_instances",
          DashboardManagement.WidgetInstanceController,

--- a/apps/acqdat_api/lib/acqdat_api_web/validators/dashboard_management/command_widget.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/validators/dashboard_management/command_widget.ex
@@ -1,0 +1,16 @@
+defmodule AcqdatApiWeb.Validators.DashboardManagement.CommandWidget do
+  use Params
+
+  defparams(
+    verify_params(%{
+      label!: :string,
+      org_id!: :integer,
+      module!: :string,
+      data_settings: :map,
+      visual_settings: :map,
+      properties: :map,
+      gateway_id!: :integer,
+      dashboard_id!: :integer
+    })
+  )
+end

--- a/apps/acqdat_api/lib/acqdat_api_web/views/dashboard_management/command_widget_view.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/views/dashboard_management/command_widget_view.ex
@@ -2,4 +2,35 @@ defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetView do
   use AcqdatApiWeb, :view
 
 
+  def render("command_widget_types.json", %{command_widget_types: command_widget_types}) do
+    %{
+      command_widget_types: render_many(command_widget_types, __MODULE__,
+        "command_widget_type.json")
+    }
+  end
+
+  def render("command_widget_type.json", %{command_widget: cw_type}) do
+    %{
+      name: cw_type.name,
+      module: cw_type.module,
+      widget_parameters: cw_type.widget_parameters,
+      image_url: cw_type.image_url,
+      widget_type: cw_type.widget_type
+    }
+  end
+
+  def render("show.json", %{command_widget: command_widget}) do
+    %{
+      id: command_widget.id,
+      uuid: command_widget.uuid,
+      gateway_id: command_widget.gateway_id,
+      dashboard_id: command_widget.dashboard_id,
+      label: command_widget.label,
+      data_settings: command_widget.data_settings,
+      visual_settings: command_widget.visual_settings,
+      command_widget_type: command_widget.command_widget_type,
+      module: command_widget.module,
+      properties: command_widget.properties
+    }
+  end
 end

--- a/apps/acqdat_api/lib/acqdat_api_web/views/dashboard_management/command_widget_view.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/views/dashboard_management/command_widget_view.ex
@@ -1,11 +1,10 @@
 defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetView do
   use AcqdatApiWeb, :view
 
-
   def render("command_widget_types.json", %{command_widget_types: command_widget_types}) do
     %{
-      command_widget_types: render_many(command_widget_types, __MODULE__,
-        "command_widget_type.json")
+      command_widget_types:
+        render_many(command_widget_types, __MODULE__, "command_widget_type.json")
     }
   end
 

--- a/apps/acqdat_api/lib/acqdat_api_web/views/dashboard_management/command_widget_view.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/views/dashboard_management/command_widget_view.ex
@@ -1,0 +1,5 @@
+defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetView do
+  use AcqdatApiWeb, :view
+
+
+end

--- a/apps/acqdat_api/test/acqdat_api_web/controllers/dashboard-management/command_widget_controller_test.exs
+++ b/apps/acqdat_api/test/acqdat_api_web/controllers/dashboard-management/command_widget_controller_test.exs
@@ -16,14 +16,17 @@ defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetControllerTest do
     test "returns a list of command_widget types", context do
       %{org: org, conn: conn} = context
 
-      result = get(conn, Routes.command_widget_path(conn, :command_widget_types,
-        org.id)) |> json_response(200)
+      result =
+        get(conn, Routes.command_widget_path(conn, :command_widget_types, org.id))
+        |> json_response(200)
+
       assert Map.has_key?(result, "command_widget_types")
     end
   end
 
   describe "create/2 " do
     setup :setup_conn
+
     setup do
       org = insert(:organisation)
       dashboard = insert(:dashboard, org: org)
@@ -36,16 +39,24 @@ defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetControllerTest do
       %{gateway: gateway, dashboard: dashboard, conn: conn, org: org} = context
       module = "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl"
       data_settings = setup_data()
+
       params = %{
-        "gateway_id" => gateway.id, "dashboard_id" => dashboard.id, "module" => module,
-        "data_settings" => data_settings, "visual_settings" => %{},
-        "label"=> "LED Control Panel"
+        "gateway_id" => gateway.id,
+        "dashboard_id" => dashboard.id,
+        "module" => module,
+        "data_settings" => data_settings,
+        "visual_settings" => %{},
+        "label" => "LED Control Panel"
       }
 
-      result = conn
-      |> post(Routes.command_widget_path(conn, :create, org.id,
-        dashboard.id), params)
-      |> json_response(200)
+      result =
+        conn
+        |> post(
+          Routes.command_widget_path(conn, :create, org.id, dashboard.id),
+          params
+        )
+        |> json_response(200)
+
       assert result["label"] == params["label"]
       assert result["gateway_id"] == params["gateway_id"]
     end
@@ -54,25 +65,31 @@ defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetControllerTest do
       %{dashboard: dashboard, conn: conn, org: org} = context
       module = "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl"
       data_settings = setup_data()
+
       params = %{
-        "gateway_id" => -1, "dashboard_id" => dashboard.id, "module" => module,
-        "data_settings" => data_settings, "visual_settings" => %{},
-        "label"=> "LED Control Panel"
+        "gateway_id" => -1,
+        "dashboard_id" => dashboard.id,
+        "module" => module,
+        "data_settings" => data_settings,
+        "visual_settings" => %{},
+        "label" => "LED Control Panel"
       }
 
-      result = conn
-      |> post(Routes.command_widget_path(conn, :create, org.id,
-        dashboard.id), params)
-      |> json_response(400)
+      result =
+        conn
+        |> post(
+          Routes.command_widget_path(conn, :create, org.id, dashboard.id),
+          params
+        )
+        |> json_response(400)
 
-      assert %{"errors" => %{
-        "message" => %{"gateway" => ["does not exist"]}}
-        } == result
+      assert %{"errors" => %{"message" => %{"gateway" => ["does not exist"]}}} == result
     end
   end
 
   describe "update/2 " do
     setup :setup_conn
+
     setup do
       org = insert(:organisation)
       dashboard = insert(:dashboard, org: org)
@@ -87,14 +104,21 @@ defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetControllerTest do
       data_settings = setup_data()
       params = %{"data_settings" => data_settings}
 
-      result = put(conn, Routes.command_widget_path(conn, :update,
-        org.id, dashboard.id, command_widget.id), params) |> json_response(200)
+      result =
+        put(
+          conn,
+          Routes.command_widget_path(conn, :update, org.id, dashboard.id, command_widget.id),
+          params
+        )
+        |> json_response(200)
+
       assert command_widget.data_settings != result["data_settings"]
     end
   end
 
   describe "delete/2 " do
     setup :setup_conn
+
     setup do
       org = insert(:organisation)
       dashboard = insert(:dashboard, org: org)
@@ -106,8 +130,11 @@ defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetControllerTest do
       %{org: org, dashboard: dashboard, conn: conn} = context
       command_widget = insert(:command_widget)
 
-      delete(conn, Routes.command_widget_path(conn, :delete, org.id,
-        dashboard.id, command_widget.id)) |> json_response(200)
+      delete(
+        conn,
+        Routes.command_widget_path(conn, :delete, org.id, dashboard.id, command_widget.id)
+      )
+      |> json_response(200)
 
       response = Repo.get(CommandWidget, command_widget.id)
       assert response == nil
@@ -128,10 +155,28 @@ defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetControllerTest do
         "default" => 2,
         "value" => 2
       },
-      "rgb_color" => %{"html_tag" => "input", "html_type" => "color", "value" => [0,12,23]},
-      "intensity" => %{"html_tag" => "input", "html_type" => "range", "min" => 0, "max" => 255, "value" => 100},
-      "warm_white" => %{"html_tag" => "input", "html_type" => "range", "min" => 0, "max" => 30_000, "value" => 100},
-      "cold_white" => %{"html_tag" => "input", "html_type" => "range", "min" => 0, "max" => 30_000, "value" => 100}
+      "rgb_color" => %{"html_tag" => "input", "html_type" => "color", "value" => [0, 12, 23]},
+      "intensity" => %{
+        "html_tag" => "input",
+        "html_type" => "range",
+        "min" => 0,
+        "max" => 255,
+        "value" => 100
+      },
+      "warm_white" => %{
+        "html_tag" => "input",
+        "html_type" => "range",
+        "min" => 0,
+        "max" => 30_000,
+        "value" => 100
+      },
+      "cold_white" => %{
+        "html_tag" => "input",
+        "html_type" => "range",
+        "min" => 0,
+        "max" => 30_000,
+        "value" => 100
+      }
     }
   end
 end

--- a/apps/acqdat_api/test/acqdat_api_web/controllers/dashboard-management/command_widget_controller_test.exs
+++ b/apps/acqdat_api/test/acqdat_api_web/controllers/dashboard-management/command_widget_controller_test.exs
@@ -1,0 +1,137 @@
+defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetControllerTest do
+  use ExUnit.Case, async: true
+  use AcqdatApiWeb.ConnCase
+  use AcqdatCore.DataCase
+  import AcqdatCore.Support.Factory
+  alias AcqdatCore.DashboardManagement.Schema.CommandWidget
+
+  describe "command_widget_types/2 " do
+    setup :setup_conn
+
+    setup do
+      org = insert(:organisation)
+      [org: org]
+    end
+
+    test "returns a list of command_widget types", context do
+      %{org: org, conn: conn} = context
+
+      result = get(conn, Routes.command_widget_path(conn, :command_widget_types,
+        org.id)) |> json_response(200)
+      assert Map.has_key?(result, "command_widget_types")
+    end
+  end
+
+  describe "create/2 " do
+    setup :setup_conn
+    setup do
+      org = insert(:organisation)
+      dashboard = insert(:dashboard, org: org)
+      gateway = insert(:gateway, org: org)
+
+      [gateway: gateway, dashboard: dashboard, org: org]
+    end
+
+    test "creates a command widget", context do
+      %{gateway: gateway, dashboard: dashboard, conn: conn, org: org} = context
+      module = "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl"
+      data_settings = setup_data()
+      params = %{
+        "gateway_id" => gateway.id, "dashboard_id" => dashboard.id, "module" => module,
+        "data_settings" => data_settings, "visual_settings" => %{},
+        "label"=> "LED Control Panel"
+      }
+
+      result = conn
+      |> post(Routes.command_widget_path(conn, :create, org.id,
+        dashboard.id), params)
+      |> json_response(200)
+      assert result["label"] == params["label"]
+      assert result["gateway_id"] == params["gateway_id"]
+    end
+
+    test "fails if error", context do
+      %{dashboard: dashboard, conn: conn, org: org} = context
+      module = "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl"
+      data_settings = setup_data()
+      params = %{
+        "gateway_id" => -1, "dashboard_id" => dashboard.id, "module" => module,
+        "data_settings" => data_settings, "visual_settings" => %{},
+        "label"=> "LED Control Panel"
+      }
+
+      result = conn
+      |> post(Routes.command_widget_path(conn, :create, org.id,
+        dashboard.id), params)
+      |> json_response(400)
+
+      assert %{"errors" => %{
+        "message" => %{"gateway" => ["does not exist"]}}
+        } == result
+    end
+  end
+
+  describe "update/2 " do
+    setup :setup_conn
+    setup do
+      org = insert(:organisation)
+      dashboard = insert(:dashboard, org: org)
+      gateway = insert(:gateway, org: org)
+
+      [gateway: gateway, dashboard: dashboard, org: org]
+    end
+
+    test "update data settings", context do
+      %{dashboard: dashboard, conn: conn, org: org} = context
+      command_widget = insert(:command_widget)
+      data_settings = setup_data()
+      params = %{"data_settings" => data_settings}
+
+      result = put(conn, Routes.command_widget_path(conn, :update,
+        org.id, dashboard.id, command_widget.id), params) |> json_response(200)
+      assert command_widget.data_settings != result["data_settings"]
+    end
+  end
+
+  describe "delete/2 " do
+    setup :setup_conn
+    setup do
+      org = insert(:organisation)
+      dashboard = insert(:dashboard, org: org)
+
+      [dashboard: dashboard, org: org]
+    end
+
+    test "deletes a command widget", context do
+      %{org: org, dashboard: dashboard, conn: conn} = context
+      command_widget = insert(:command_widget)
+
+      delete(conn, Routes.command_widget_path(conn, :delete, org.id,
+        dashboard.id, command_widget.id)) |> json_response(200)
+
+      response = Repo.get(CommandWidget, command_widget.id)
+      assert response == nil
+    end
+  end
+
+  defp setup_data() do
+    %{
+      "rgb_mode" => %{
+        "html_tag" => "select",
+        "source" => %{"off" => 0, "spectrum cycling" => 1, "breathing" => 2, "solid" => 3},
+        "default" => 3,
+        "value" => 1
+      },
+      "w_mode" => %{
+        "html_type" => "select",
+        "source" => %{"off" => 0, "breathing" => 1, "solid" => 2},
+        "default" => 2,
+        "value" => 2
+      },
+      "rgb_color" => %{"html_tag" => "input", "html_type" => "color", "value" => [0,12,23]},
+      "intensity" => %{"html_tag" => "input", "html_type" => "range", "min" => 0, "max" => 255, "value" => 100},
+      "warm_white" => %{"html_tag" => "input", "html_type" => "range", "min" => 0, "max" => 30_000, "value" => 100},
+      "cold_white" => %{"html_tag" => "input", "html_type" => "range", "min" => 0, "max" => 30_000, "value" => 100}
+    }
+  end
+end

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/command_widget.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/command_widget.ex
@@ -1,0 +1,45 @@
+defmodule AcqdatCore.Model.DashboardManagement.CommandWidget do
+  @moduledoc """
+  Exposes functions to work with command widgets.
+  """
+  alias AcqdatCore.DashboardManagement.Schema.CommandWidget
+  alias AcqdatCore.Repo
+
+  def create(params) do
+    changeset = CommandWidget.changeset(%CommandWidget{}, params)
+    Repo.insert(changeset)
+  end
+
+  def update(command_widget, %{"data_settings" => _data_settings} = params) do
+    changeset = CommandWidget.changeset(command_widget, params)
+    {:ok, command_widget} = Repo.update(changeset)
+    command_widget.module.handle_command(command_widget.data_settings)
+    command_widget
+  end
+
+  def update(command_widget, params) do
+    changeset = CommandWidget.changeset(command_widget, params)
+    Repo.update(changeset)
+  end
+
+  def get(id) when is_integer(id) do
+
+  end
+
+  def get_all_by_dashboard_id(dashboard_id) do
+
+  end
+
+  def get_command_widget_types() do
+    values = CommandWidgetSchemaEnum.__valid_values__()
+    values
+    |> Stream.filter(fn value -> is_atom(value) end)
+    |> Enum.map(fn module ->
+      %{
+        name: module.widget_name,
+        module: module,
+        widget_parameters: module.widget_parameters
+      }
+    end)
+  end
+end

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/command_widget.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/command_widget.ex
@@ -13,7 +13,7 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidget do
   def update(command_widget, %{"data_settings" => _data_settings} = params) do
     changeset = CommandWidget.changeset(command_widget, params)
     {:ok, command_widget} = Repo.update(changeset)
-    command_widget.module.handle_command(command_widget.data_settings)
+    command_widget.module.handle_command(command_widget)
     command_widget
   end
 

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/command_widget.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/command_widget.ex
@@ -25,6 +25,7 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidget do
     case Repo.get(CommandWidget, id) do
       nil ->
         {:error, "Command Widget not found"}
+
       command_widget ->
         {:ok, command_widget}
     end
@@ -34,21 +35,25 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidget do
     case Repo.get_by(CommandWidget, params) do
       nil ->
         {:error, "Command Widget not found"}
+
       command_widget ->
         {:ok, command_widget}
     end
   end
 
   def get_all_by_dashboard_id(dashboard_id) do
-    query = from(
-      widget in CommandWidget,
-      where: widget.dashboard_id == ^dashboard_id
-    )
+    query =
+      from(
+        widget in CommandWidget,
+        where: widget.dashboard_id == ^dashboard_id
+      )
+
     Repo.all(query)
   end
 
   def get_command_widget_types() do
     values = CommandWidgetSchemaEnum.__valid_values__()
+
     values
     |> Stream.filter(fn value -> is_atom(value) end)
     |> Enum.map(fn module ->

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/command_widget.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/command_widget.ex
@@ -55,7 +55,9 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidget do
       %{
         name: module.widget_name,
         module: module,
-        widget_parameters: module.widget_parameters
+        widget_parameters: module.widget_parameters,
+        image_url: module.image_url,
+        widget_type: module.widget_type
       }
     end)
   end

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/command_widget.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/command_widget.ex
@@ -4,6 +4,7 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidget do
   """
   alias AcqdatCore.DashboardManagement.Schema.CommandWidget
   alias AcqdatCore.Repo
+  import Ecto.Query
 
   def create(params) do
     changeset = CommandWidget.changeset(%CommandWidget{}, params)
@@ -12,9 +13,7 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidget do
 
   def update(command_widget, %{"data_settings" => _data_settings} = params) do
     changeset = CommandWidget.changeset(command_widget, params)
-    {:ok, command_widget} = Repo.update(changeset)
-    command_widget.module.handle_command(command_widget)
-    command_widget
+    verify_update(Repo.update(changeset))
   end
 
   def update(command_widget, params) do
@@ -23,11 +22,29 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidget do
   end
 
   def get(id) when is_integer(id) do
+    case Repo.get(CommandWidget, id) do
+      nil ->
+        {:error, "Command Widget not found"}
+      command_widget ->
+        {:ok, command_widget}
+    end
+  end
 
+  def get(params) when is_map(params) do
+    case Repo.get_by(CommandWidget, params) do
+      nil ->
+        {:error, "Command Widget not found"}
+      command_widget ->
+        {:ok, command_widget}
+    end
   end
 
   def get_all_by_dashboard_id(dashboard_id) do
-
+    query = from(
+      widget in CommandWidget,
+      where: widget.dashboard_id == ^dashboard_id
+    )
+    Repo.all(query)
   end
 
   def get_command_widget_types() do
@@ -42,4 +59,18 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidget do
       }
     end)
   end
+
+  def delete(command_widget) do
+    Repo.delete(command_widget)
+  end
+
+  ################# private functions ###############
+
+  defp verify_update({:ok, command_widget}) do
+    command_widget = Repo.preload(command_widget, :gateway)
+    command_widget.module.handle_command(command_widget)
+    {:ok, command_widget}
+  end
+
+  defp verify_update({:error, _error} = error), do: error
 end

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/dashboard.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/dashboard.ex
@@ -2,6 +2,7 @@ defmodule AcqdatCore.Model.DashboardManagement.Dashboard do
   import Ecto.Query
   alias AcqdatCore.DashboardManagement.Schema.Dashboard
   alias AcqdatCore.Model.DashboardManagement.WidgetInstance, as: WidgetInstanceModel
+  alias AcqdatCore.Model.DashboardManagement.CommandWidget
   alias AcqdatCore.Repo
 
   def create(params) do
@@ -35,7 +36,11 @@ defmodule AcqdatCore.Model.DashboardManagement.Dashboard do
 
       dashboard ->
         widgets = WidgetInstanceModel.get_all_by_dashboard_id(dashboard.id)
-        dashboard = Map.put(dashboard, :widgets, widgets)
+        command_widgets = CommandWidget.get_all_by_dashboard_id(dashboard.id)
+        dashboard =
+          dashboard
+          |> Map.put(:widgets, widgets)
+          |> Map.put(:command_widgets, command_widgets)
         {:ok, dashboard}
     end
   end

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/dashboard.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/dashboard.ex
@@ -37,10 +37,12 @@ defmodule AcqdatCore.Model.DashboardManagement.Dashboard do
       dashboard ->
         widgets = WidgetInstanceModel.get_all_by_dashboard_id(dashboard.id)
         command_widgets = CommandWidget.get_all_by_dashboard_id(dashboard.id)
+
         dashboard =
           dashboard
           |> Map.put(:widgets, widgets)
           |> Map.put(:command_widgets, command_widgets)
+
         {:ok, dashboard}
     end
   end

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/command_widget/command_widget.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/command_widget/command_widget.ex
@@ -1,0 +1,63 @@
+defmodule AcqdatCore.DashboardManagement.Schema.CommandWidget do
+  @moduledoc """
+  Models a command widget.
+  """
+
+  use AcqdatCore.Schema
+  alias AcqdatCore.Schema.IotManager.Gateway
+  alias AcqdatCore.DashboardManagement.Schema.Dashboard
+  @callback handle_command(data_setting_parameters :: map) ::
+    {:ok, String.t()} | {:error, String.t()}
+
+  @callback widget_parameters() :: map
+  @callback widget_type() :: String.t()
+  @callback widget_name() :: String.t()
+
+  @type t :: %__MODULE__{}
+
+  schema("acqdat_command_widgets") do
+    field(:label, :string, null: false)
+    field(:properties, :map)
+    field(:uuid, :string)
+    field(:module, CommandWidgetSchemaEnum)
+    field(:visual_settings, :map)
+    field(:data_settings, :map)
+    field(:command_widget_type, :string)
+
+    # associations
+    belongs_to(:gateway, Gateway, on_replace: :delete)
+    belongs_to(:dashboard, Dashboard, on_replace: :delete)
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @required ~w(label module gateway_id dashboard_id)a
+  @optional ~w(properties uuid data_settings
+    visual_settings command_widget_type)a
+  @permitted @required ++ @optional
+
+  def changeset(%__MODULE__{}=command_widget, params) do
+    command_widget
+    |> cast(params, @permitted)
+    |> add_uuid()
+    |> validate_required(@required)
+    |> add_command_widget_type()
+    |> assoc_constraint(:gateway)
+    |> assoc_constraint(:dashboard)
+  end
+
+  defp add_uuid(%Ecto.Changeset{valid?: true} = changeset) do
+    changeset
+    |> put_change(:uuid, UUID.uuid1(:hex))
+  end
+
+  defp add_command_widget_type(%Ecto.Changeset{valid?: true} = changeset) do
+    module = get_field(changeset, :module)
+    widget_type = module.widget_type
+    changeset
+    |> put_change(:command_widget_type, widget_type)
+  end
+
+  defp add_command_widget_type(changeset), do: changeset
+
+end

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/command_widget/command_widget.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/command_widget/command_widget.ex
@@ -6,8 +6,9 @@ defmodule AcqdatCore.DashboardManagement.Schema.CommandWidget do
   use AcqdatCore.Schema
   alias AcqdatCore.Schema.IotManager.Gateway
   alias AcqdatCore.DashboardManagement.Schema.Dashboard
+
   @callback handle_command(data_setting_parameters :: map) ::
-    {:ok, String.t()} | {:error, String.t()}
+              {:ok, String.t()} | {:error, String.t()}
 
   @callback widget_parameters() :: map
   @callback widget_type() :: String.t()
@@ -37,7 +38,7 @@ defmodule AcqdatCore.DashboardManagement.Schema.CommandWidget do
     visual_settings command_widget_type)a
   @permitted @required ++ @optional
 
-  def changeset(%__MODULE__{}=command_widget, params) do
+  def changeset(%__MODULE__{} = command_widget, params) do
     command_widget
     |> cast(params, @permitted)
     |> add_uuid()
@@ -55,10 +56,10 @@ defmodule AcqdatCore.DashboardManagement.Schema.CommandWidget do
   defp add_command_widget_type(%Ecto.Changeset{valid?: true} = changeset) do
     module = get_field(changeset, :module)
     widget_type = module.widget_type
+
     changeset
     |> put_change(:command_widget_type, widget_type)
   end
 
   defp add_command_widget_type(changeset), do: changeset
-
 end

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/command_widget/command_widget.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/command_widget/command_widget.ex
@@ -12,6 +12,7 @@ defmodule AcqdatCore.DashboardManagement.Schema.CommandWidget do
   @callback widget_parameters() :: map
   @callback widget_type() :: String.t()
   @callback widget_name() :: String.t()
+  @callback image_url() :: String.t()
 
   @type t :: %__MODULE__{}
 

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/command_widget/command_widget_enum.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/command_widget/command_widget_enum.ex
@@ -1,0 +1,8 @@
+import EctoEnum
+
+# creates a widget vendor schema enum. The schema enum
+# contains the name of the module which will define the module
+# contianing all the key definitions for a vendor.
+defenum(CommandWidgetSchemaEnum,
+  "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl": 0
+)

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/command_widget/led_control.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/command_widget/led_control.ex
@@ -1,0 +1,54 @@
+defmodule AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl do
+  @moduledoc """
+  Adds schema and controls for LEDControl Widget.
+  """
+  use AcqdatCore.Schema
+  @behaviour AcqdatCore.DashboardManagement.Schema.CommandWidget
+  @widget_type "html"
+  @widget_name "LED Control"
+
+  defstruct [
+    gateway: nil,
+    data_settings: %{
+      rgb_mode: %{
+        html_tag: "select",
+        source: %{"off" => 0, "spectrum cycling" => 1, "breathing" => 2, "solid" => 3},
+        default: 3,
+        value: nil
+      },
+      w_mode: %{
+        html_type: "select",
+        source: %{"off" => 0, "breathing" => 1, "solid" => 2},
+        default: 2,
+        value: nil
+      },
+      rgb_color: %{html_tag: "input", html_type: "color", value: nil},
+      intensity: %{html_tag: "input", html_type: "range", min: 0, max: 255, value: nil},
+      warm_white: %{html_tag: "input", html_type: "range", min: 0, max: 30_000, value: nil},
+      cold_white: %{html_tag: "input", html_type: "range", min: 0, max: 30_000, value: nil}
+    },
+    visual_settings: %{
+    },
+    image_url: ""
+  ]
+
+  @impl true
+  def handle_command(_params) do
+    {:ok, ""}
+  end
+
+  @impl true
+  def widget_type() do
+    @widget_type
+  end
+
+  @impl true
+  def widget_parameters() do
+    Map.from_struct(__MODULE__)
+  end
+
+  @impl true
+  def widget_name() do
+    @widget_name
+  end
+end

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/command_widget/led_control.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/command_widget/led_control.ex
@@ -8,44 +8,55 @@ defmodule AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl do
   @widget_type "html"
   @widget_name "LED Control"
 
-  defstruct [
-    gateway: nil,
-    data_settings: %{
-      rgb_mode: %{
-        html_tag: "select",
-        source: %{"off" => 0, "spectrum cycling" => 1, "breathing" => 2, "solid" => 3},
-        default: 3,
-        value: nil
-      },
-      w_mode: %{
-        html_tag: "select",
-        source: %{"off" => 0, "breathing" => 1, "solid" => 2},
-        default: 2,
-        value: nil
-      },
-      rgb_color: %{html_tag: "input", html_type: "color", value: nil},
-      intensity: %{html_tag: "input", html_type: "range", min: 0, max: 255, value: nil},
-      warm_white: %{html_tag: "input", html_type: "range", min: 0, max: 30_000, value: nil},
-      cold_white: %{html_tag: "input", html_type: "range", min: 0, max: 30_000, value: nil}
-    },
-    visual_settings: %{
-    },
-    image_url: ""
-  ]
+  defstruct gateway: nil,
+            data_settings: %{
+              rgb_mode: %{
+                html_tag: "select",
+                source: %{"off" => 0, "spectrum cycling" => 1, "breathing" => 2, "solid" => 3},
+                default: 3,
+                value: nil
+              },
+              w_mode: %{
+                html_tag: "select",
+                source: %{"off" => 0, "breathing" => 1, "solid" => 2},
+                default: 2,
+                value: nil
+              },
+              rgb_color: %{html_tag: "input", html_type: "color", value: nil},
+              intensity: %{html_tag: "input", html_type: "range", min: 0, max: 255, value: nil},
+              warm_white: %{
+                html_tag: "input",
+                html_type: "range",
+                min: 0,
+                max: 30_000,
+                value: nil
+              },
+              cold_white: %{
+                html_tag: "input",
+                html_type: "range",
+                min: 0,
+                max: 30_000,
+                value: nil
+              }
+            },
+            visual_settings: %{},
+            image_url: ""
 
   @impl true
-  #TODO: Handles only mqtt need to handle http
+  # TODO: Handles only mqtt need to handle http
   def handle_command(command_widget, _options \\ []) do
-    data = command_widget.data_settings
-    |> Enum.reduce(%{}, fn
-      {"rgb_color", value}, acc ->
-        acc
-        |> Map.put(:red, Enum.at(value["value"], 0))
-        |> Map.put(:green, Enum.at(value["value"], 1))
-        |> Map.put(:blue, Enum.at(value["value"], 2))
-      {key, value}, acc ->
-        Map.put(acc, key, value["value"])
-    end)
+    data =
+      command_widget.data_settings
+      |> Enum.reduce(%{}, fn
+        {"rgb_color", value}, acc ->
+          acc
+          |> Map.put(:red, Enum.at(value["value"], 0))
+          |> Map.put(:green, Enum.at(value["value"], 1))
+          |> Map.put(:blue, Enum.at(value["value"], 2))
+
+        {key, value}, acc ->
+          Map.put(acc, key, value["value"])
+      end)
 
     prepare_payload_and_send(command_widget, data)
   end
@@ -73,7 +84,9 @@ defmodule AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl do
   defp prepare_payload_and_send(command_widget, data) do
     actuator_payload = Map.put(%{}, :actuator, data)
     current_timestamp = DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_unix()
-    data_payload = %{}
+
+    data_payload =
+      %{}
       |> Map.put(:data, actuator_payload)
       |> Map.put(:timestamp, current_timestamp)
       |> Map.put(:gateway_id, command_widget.gateway_id)

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/command_widget/led_control.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/command_widget/led_control.ex
@@ -17,7 +17,7 @@ defmodule AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl do
         value: nil
       },
       w_mode: %{
-        html_type: "select",
+        html_tag: "select",
         source: %{"off" => 0, "breathing" => 1, "solid" => 2},
         default: 2,
         value: nil
@@ -33,7 +33,9 @@ defmodule AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl do
   ]
 
   @impl true
-  def handle_command(_params) do
+  def handle_command(params) do
+    require IEx
+    IEx.pry
     {:ok, ""}
   end
 

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/command_widget/led_control.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/command_widget/led_control.ex
@@ -3,6 +3,7 @@ defmodule AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl do
   Adds schema and controls for LEDControl Widget.
   """
   use AcqdatCore.Schema
+  alias AcqdatCore.Model.IotManager.Gateway
   @behaviour AcqdatCore.DashboardManagement.Schema.CommandWidget
   @widget_type "html"
   @widget_name "LED Control"
@@ -33,10 +34,19 @@ defmodule AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl do
   ]
 
   @impl true
-  def handle_command(params) do
-    require IEx
-    IEx.pry
-    {:ok, ""}
+  #TODO: Handles only mqtt need to handle http
+  def handle_command(command_widget, _options \\ []) do
+    data = command_widget.data_settings
+    |> Enum.reduce(%{}, fn
+      {:rgb_color, value}, acc ->
+        acc
+        |> Map.put(:red, Enum.at(value.value, 0))
+        |> Map.put(:green, Enum.at(value.value, 1))
+        |> Map.put(:blue, Enum.at(value.value, 2))
+      {key, value}, acc ->
+        Map.put(acc, key, value.value)
+    end)
+    prepare_payload_and_send(command_widget, data)
   end
 
   @impl true
@@ -52,5 +62,19 @@ defmodule AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl do
   @impl true
   def widget_name() do
     @widget_name
+  end
+
+  defp prepare_payload_and_send(command_widget, data) do
+    actuator_payload = Map.put(%{}, :actuator, data)
+    current_timestamp = DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_unix()
+    data_payload = %{}
+      |> Map.put(:data, actuator_payload)
+      |> Map.put(:timestamp, current_timestamp)
+      |> Map.put(:gateway_id, command_widget.gateway_id)
+      |> Map.put(:project_id, command_widget.gateway.project_id)
+      |> Map.put(:org_id, command_widget.gateway.org_id)
+
+    Gateway.send_mqtt_command(command_widget.gateway, data_payload)
+    {:ok, "Command Sent"}
   end
 end

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/command_widget/led_control.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/command_widget/led_control.ex
@@ -38,14 +38,15 @@ defmodule AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl do
   def handle_command(command_widget, _options \\ []) do
     data = command_widget.data_settings
     |> Enum.reduce(%{}, fn
-      {:rgb_color, value}, acc ->
+      {"rgb_color", value}, acc ->
         acc
-        |> Map.put(:red, Enum.at(value.value, 0))
-        |> Map.put(:green, Enum.at(value.value, 1))
-        |> Map.put(:blue, Enum.at(value.value, 2))
+        |> Map.put(:red, Enum.at(value["value"], 0))
+        |> Map.put(:green, Enum.at(value["value"], 1))
+        |> Map.put(:blue, Enum.at(value["value"], 2))
       {key, value}, acc ->
-        Map.put(acc, key, value.value)
+        Map.put(acc, key, value["value"])
     end)
+
     prepare_payload_and_send(command_widget, data)
   end
 
@@ -62,6 +63,11 @@ defmodule AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl do
   @impl true
   def widget_name() do
     @widget_name
+  end
+
+  @impl true
+  def image_url() do
+    ""
   end
 
   defp prepare_payload_and_send(command_widget, data) do

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/dashboard.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/dashboard.ex
@@ -10,7 +10,7 @@ defmodule AcqdatCore.DashboardManagement.Schema.Dashboard do
   """
   use AcqdatCore.Schema
   alias AcqdatCore.Schema.EntityManagement.Organisation
-  alias AcqdatCore.DashboardManagement.Schema.WidgetInstance
+  alias AcqdatCore.DashboardManagement.Schema.{WidgetInstance, CommandWidget}
 
   @typedoc """
   `name`: Name of the dashboard, which will be unique with respective to org.
@@ -29,6 +29,7 @@ defmodule AcqdatCore.DashboardManagement.Schema.Dashboard do
     # associations
     belongs_to(:org, Organisation, on_replace: :delete)
     has_many(:widget_instances, WidgetInstance, on_replace: :delete)
+    has_many(:command_widgets, CommandWidget)
 
     timestamps(type: :utc_datetime)
   end

--- a/apps/acqdat_core/lib/acqdat_core/iot-manager/model/gateway.ex
+++ b/apps/acqdat_core/lib/acqdat_core/iot-manager/model/gateway.ex
@@ -218,6 +218,8 @@ defmodule AcqdatCore.Model.IotManager.Gateway do
     MQTTBroker.publish(project.uuid, topic, Jason.encode!(payload))
   end
 
+  @spec send_mqtt_command(Gateway.t(), map()) ::
+          :ok | {:error, :unknown_connection} | {:ok, reference}
   def send_mqtt_command(gateway, payload) do
     gateway = Repo.preload(gateway, project: :org)
     project = gateway.project

--- a/apps/acqdat_core/lib/acqdat_core/iot-manager/model/mqtt/mqtt_broker.ex
+++ b/apps/acqdat_core/lib/acqdat_core/iot-manager/model/mqtt/mqtt_broker.ex
@@ -7,6 +7,7 @@ defmodule AcqdatCore.Model.IotManager.MQTTBroker do
   alias AcqdatCore.Model.IotManager.MQTT.BrokerCredentials
 
   # TODO log error if client dosen't start for some reason
+  # TODO Add mox to handle all mqtt broker related mocks.
   def start_project_client(project_uuid, subscription_topics, password) do
     [host: host, port: port] = Application.get_env(:acqdat_core, :mqtt_broker)
 

--- a/apps/acqdat_core/priv/repo/migrations/20200805045102_add_command_widgets.exs
+++ b/apps/acqdat_core/priv/repo/migrations/20200805045102_add_command_widgets.exs
@@ -1,0 +1,21 @@
+defmodule AcqdatCore.Repo.Migrations.AddCommandWidgets do
+  use Ecto.Migration
+
+  def change do
+    create table("acqdat_command_widgets") do
+      add(:label, :string, null: false)
+      add(:properties, :map)
+      add(:uuid, :string)
+      add(:module, CommandWidgetSchemaEnum.type, null: false)
+      add(:visual_settings, :map)
+      add(:data_settings, :map)
+      add(:command_widget_type, :string, null: false)
+
+      # associations
+      add(:gateway_id, references("acqdat_gateway", on_delete: :delete_all), null: false)
+      add(:dashboard_id, references("acqdat_dashboard", on_delete: :delete_all), null: false)
+
+      timestamps(type: :timestamptz)
+    end
+  end
+end

--- a/apps/acqdat_core/test/dashboard_management/model/command_widget_model_test.exs
+++ b/apps/acqdat_core/test/dashboard_management/model/command_widget_model_test.exs
@@ -51,6 +51,7 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidgetTest do
       refute updated_command_widget.label == command_widget.label
     end
 
+    # TODO add mock for mqtt
     test "update with data settings", context do
       %{gateway: gateway, dashboard: dasbhoard} = context
       module = "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl"
@@ -65,9 +66,59 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidgetTest do
       data = setup_data()
       update_params = %{"label" => "LED Panel", "data_settings" => data}
       {:ok, updated_command_widget} = CommandWidget.update(command_widget, update_params)
-
+      assert updated_command_widget.id == command_widget.id
+      assert updated_command_widget.label != command_widget.label
     end
   end
+
+  describe "get/1 " do
+    setup  do
+      dashboard = insert(:dashboard)
+      command_widgets = insert_list(3, :command_widget, dashboard: dashboard)
+      [command_widgets: command_widgets]
+    end
+
+    test "command widget by id", context do
+      %{command_widgets: [cw1, _cw_2, _cw_3]} = context
+      {:ok, widget} = CommandWidget.get(cw1.id)
+      assert widget.id == cw1.id
+    end
+
+    test "command widget by uuid", context do
+      %{command_widgets: [cw1, _cw_2, _cw_3]} = context
+      {:ok, widget} = CommandWidget.get(%{uuid: cw1.uuid})
+      assert widget.id == cw1.id
+    end
+  end
+
+  describe "get_all_by_dashboard_id/1 " do
+    setup  do
+      dashboard = insert(:dashboard)
+      command_widgets = insert_list(3, :command_widget, dashboard: dashboard)
+      [command_widgets: command_widgets]
+    end
+
+    test "returns command widget with id", context do
+      %{command_widgets: [cw1, _cw_2, _cw_3]} = context
+      widgets = CommandWidget.get_all_by_dashboard_id(cw1.dashboard_id)
+      assert length(widgets) == 3
+    end
+
+    test "returns empty if none found", context do
+      dashboard = insert(:dashboard)
+      widgets = CommandWidget.get_all_by_dashboard_id(dashboard.id)
+      assert widgets == []
+    end
+  end
+
+  describe "delete/1" do
+    test "deletes a command widget" do
+      command_widget = insert(:command_widget)
+      assert {:ok, _result} = CommandWidget.delete(command_widget)
+      assert {:error, "Command Widget not found"} == CommandWidget.get(command_widget.id)
+    end
+  end
+
 
   defp setup_data() do
     %{

--- a/apps/acqdat_core/test/dashboard_management/model/command_widget_model_test.exs
+++ b/apps/acqdat_core/test/dashboard_management/model/command_widget_model_test.exs
@@ -1,0 +1,92 @@
+defmodule AcqdatCore.Model.DashboardManagement.CommandWidgetTest do
+  use ExUnit.Case, async: true
+  use AcqdatCore.DataCase
+  import AcqdatCore.Support.Factory
+  alias AcqdatCore.Model.DashboardManagement.CommandWidget
+
+  describe "create/1 " do
+    setup do
+      dashboard = insert(:dashboard)
+      gateway = insert(:gateway)
+
+      [gateway: gateway, dashboard: dashboard]
+    end
+
+    test "creates a command widget with supplied params", context do
+      %{gateway: gateway, dashboard: dasbhoard} = context
+      module = "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl"
+      data_settings = setup_data()
+      params = %{
+        gateway_id: gateway.id, dashboard_id: dasbhoard.id, module: module,
+        data_settings: data_settings, visual_settings: %{},
+        label: "LED Control Panel"
+      }
+
+      assert {:ok, command_widget} = CommandWidget.create(params)
+    end
+  end
+
+  describe "update/2 " do
+    setup do
+      dashboard = insert(:dashboard)
+      gateway = insert(:gateway)
+
+      [gateway: gateway, dashboard: dashboard]
+    end
+
+    test "update without data settings", context do
+      %{gateway: gateway, dashboard: dasbhoard} = context
+      module = "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl"
+      data_settings = setup_data()
+      params = %{
+        "gateway_id" => gateway.id, "dashboard_id" => dasbhoard.id, "module" => module,
+        "data_settings" => data_settings, "visual_settings" => %{},
+        "label" => "LED Control Panel"
+      }
+      {:ok, command_widget} = CommandWidget.create(params)
+
+      update_params = %{"label" => "LED Panel"}
+      assert {:ok, updated_command_widget} = CommandWidget.update(command_widget, update_params)
+      assert updated_command_widget.id == command_widget.id
+      refute updated_command_widget.label == command_widget.label
+    end
+
+    test "update with data settings", context do
+      %{gateway: gateway, dashboard: dasbhoard} = context
+      module = "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl"
+      data_settings = setup_data()
+      params = %{
+        "gateway_id" => gateway.id, "dashboard_id" => dasbhoard.id, "module" => module,
+        "data_settings" => data_settings, "visual_settings" => %{},
+        "label" => "LED Control Panel"
+      }
+      {:ok, command_widget} = CommandWidget.create(params)
+
+      data = setup_data()
+      update_params = %{"label" => "LED Panel", "data_settings" => data}
+      {:ok, updated_command_widget} = CommandWidget.update(command_widget, update_params)
+
+    end
+  end
+
+  defp setup_data() do
+    %{
+      rgb_mode: %{
+        html_tag: "select",
+        source: %{"off" => 0, "spectrum cycling" => 1, "breathing" => 2, "solid" => 3},
+        default: 3,
+        value: 1
+      },
+      w_mode: %{
+        html_type: "select",
+        source: %{"off" => 0, "breathing" => 1, "solid" => 2},
+        default: 2,
+        value: 2
+      },
+      rgb_color: %{html_tag: "input", html_type: "color", value: [0,12,23]},
+      intensity: %{html_tag: "input", html_type: "range", min: 0, max: 255, value: 100},
+      warm_white: %{html_tag: "input", html_type: "range", min: 0, max: 30_000, value: 100},
+      cold_white: %{html_tag: "input", html_type: "range", min: 0, max: 30_000, value: 100}
+    }
+  end
+end

--- a/apps/acqdat_core/test/dashboard_management/model/command_widget_test.exs
+++ b/apps/acqdat_core/test/dashboard_management/model/command_widget_test.exs
@@ -13,11 +13,11 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidgetTest do
     end
 
     test "creates a command widget with supplied params", context do
-      %{gateway: gateway, dashboard: dasbhoard} = context
+      %{gateway: gateway, dashboard: dashboard} = context
       module = "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl"
       data_settings = setup_data()
       params = %{
-        gateway_id: gateway.id, dashboard_id: dasbhoard.id, module: module,
+        gateway_id: gateway.id, dashboard_id: dashboard.id, module: module,
         data_settings: data_settings, visual_settings: %{},
         label: "LED Control Panel"
       }
@@ -104,7 +104,7 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidgetTest do
       assert length(widgets) == 3
     end
 
-    test "returns empty if none found", context do
+    test "returns empty if none found"do
       dashboard = insert(:dashboard)
       widgets = CommandWidget.get_all_by_dashboard_id(dashboard.id)
       assert widgets == []
@@ -121,23 +121,23 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidgetTest do
 
 
   defp setup_data() do
-    %{
-      rgb_mode: %{
-        html_tag: "select",
-        source: %{"off" => 0, "spectrum cycling" => 1, "breathing" => 2, "solid" => 3},
-        default: 3,
-        value: 1
+     %{
+      "rgb_mode" => %{
+        "html_tag" => "select",
+        "source" => %{"off" => 0, "spectrum cycling" => 1, "breathing" => 2, "solid" => 3},
+        "default" => 3,
+        "value" => 1
       },
-      w_mode: %{
-        html_type: "select",
-        source: %{"off" => 0, "breathing" => 1, "solid" => 2},
-        default: 2,
-        value: 2
+      "w_mode" => %{
+        "html_type" => "select",
+        "source" => %{"off" => 0, "breathing" => 1, "solid" => 2},
+        "default" => 2,
+        "value" => 2
       },
-      rgb_color: %{html_tag: "input", html_type: "color", value: [0,12,23]},
-      intensity: %{html_tag: "input", html_type: "range", min: 0, max: 255, value: 100},
-      warm_white: %{html_tag: "input", html_type: "range", min: 0, max: 30_000, value: 100},
-      cold_white: %{html_tag: "input", html_type: "range", min: 0, max: 30_000, value: 100}
+      "rgb_color" => %{"html_tag" => "input", "html_type" => "color", "value" => [0,12,23]},
+      "intensity" => %{"html_tag" => "input", "html_type" => "range", "min" => 0, "max" => 255, "value" => 100},
+      "warm_white" => %{"html_tag" => "input", "html_type" => "range", "min" => 0, "max" => 30_000, "value" => 100},
+      "cold_white" => %{"html_tag" => "input", "html_type" => "range", "min" => 0, "max" => 30_000, "value" => 100}
     }
   end
 end

--- a/apps/acqdat_core/test/dashboard_management/model/command_widget_test.exs
+++ b/apps/acqdat_core/test/dashboard_management/model/command_widget_test.exs
@@ -16,9 +16,13 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidgetTest do
       %{gateway: gateway, dashboard: dashboard} = context
       module = "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl"
       data_settings = setup_data()
+
       params = %{
-        gateway_id: gateway.id, dashboard_id: dashboard.id, module: module,
-        data_settings: data_settings, visual_settings: %{},
+        gateway_id: gateway.id,
+        dashboard_id: dashboard.id,
+        module: module,
+        data_settings: data_settings,
+        visual_settings: %{},
         label: "LED Control Panel"
       }
 
@@ -38,11 +42,16 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidgetTest do
       %{gateway: gateway, dashboard: dasbhoard} = context
       module = "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl"
       data_settings = setup_data()
+
       params = %{
-        "gateway_id" => gateway.id, "dashboard_id" => dasbhoard.id, "module" => module,
-        "data_settings" => data_settings, "visual_settings" => %{},
+        "gateway_id" => gateway.id,
+        "dashboard_id" => dasbhoard.id,
+        "module" => module,
+        "data_settings" => data_settings,
+        "visual_settings" => %{},
         "label" => "LED Control Panel"
       }
+
       {:ok, command_widget} = CommandWidget.create(params)
 
       update_params = %{"label" => "LED Panel"}
@@ -56,11 +65,16 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidgetTest do
       %{gateway: gateway, dashboard: dasbhoard} = context
       module = "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl"
       data_settings = setup_data()
+
       params = %{
-        "gateway_id" => gateway.id, "dashboard_id" => dasbhoard.id, "module" => module,
-        "data_settings" => data_settings, "visual_settings" => %{},
+        "gateway_id" => gateway.id,
+        "dashboard_id" => dasbhoard.id,
+        "module" => module,
+        "data_settings" => data_settings,
+        "visual_settings" => %{},
         "label" => "LED Control Panel"
       }
+
       {:ok, command_widget} = CommandWidget.create(params)
 
       data = setup_data()
@@ -72,7 +86,7 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidgetTest do
   end
 
   describe "get/1 " do
-    setup  do
+    setup do
       dashboard = insert(:dashboard)
       command_widgets = insert_list(3, :command_widget, dashboard: dashboard)
       [command_widgets: command_widgets]
@@ -92,7 +106,7 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidgetTest do
   end
 
   describe "get_all_by_dashboard_id/1 " do
-    setup  do
+    setup do
       dashboard = insert(:dashboard)
       command_widgets = insert_list(3, :command_widget, dashboard: dashboard)
       [command_widgets: command_widgets]
@@ -104,7 +118,7 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidgetTest do
       assert length(widgets) == 3
     end
 
-    test "returns empty if none found"do
+    test "returns empty if none found" do
       dashboard = insert(:dashboard)
       widgets = CommandWidget.get_all_by_dashboard_id(dashboard.id)
       assert widgets == []
@@ -119,9 +133,8 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidgetTest do
     end
   end
 
-
   defp setup_data() do
-     %{
+    %{
       "rgb_mode" => %{
         "html_tag" => "select",
         "source" => %{"off" => 0, "spectrum cycling" => 1, "breathing" => 2, "solid" => 3},
@@ -134,10 +147,28 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidgetTest do
         "default" => 2,
         "value" => 2
       },
-      "rgb_color" => %{"html_tag" => "input", "html_type" => "color", "value" => [0,12,23]},
-      "intensity" => %{"html_tag" => "input", "html_type" => "range", "min" => 0, "max" => 255, "value" => 100},
-      "warm_white" => %{"html_tag" => "input", "html_type" => "range", "min" => 0, "max" => 30_000, "value" => 100},
-      "cold_white" => %{"html_tag" => "input", "html_type" => "range", "min" => 0, "max" => 30_000, "value" => 100}
+      "rgb_color" => %{"html_tag" => "input", "html_type" => "color", "value" => [0, 12, 23]},
+      "intensity" => %{
+        "html_tag" => "input",
+        "html_type" => "range",
+        "min" => 0,
+        "max" => 255,
+        "value" => 100
+      },
+      "warm_white" => %{
+        "html_tag" => "input",
+        "html_type" => "range",
+        "min" => 0,
+        "max" => 30_000,
+        "value" => 100
+      },
+      "cold_white" => %{
+        "html_tag" => "input",
+        "html_type" => "range",
+        "min" => 0,
+        "max" => 30_000,
+        "value" => 100
+      }
     }
   end
 end

--- a/apps/acqdat_core/test/dashboard_management/schema/command_widget_test.exs
+++ b/apps/acqdat_core/test/dashboard_management/schema/command_widget_test.exs
@@ -15,8 +15,14 @@ defmodule AcqdatCore.DashboardManagement.Schema.CommandWidgetTest do
     test "returns a valid changeset", context do
       %{dashboard: dashboard, gateway: gateway} = context
       module = "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl"
-      params = %{label: "LED CONTROL WIDGET", module: module,
-        gateway_id: gateway.id, dashboard_id: dashboard.id}
+
+      params = %{
+        label: "LED CONTROL WIDGET",
+        module: module,
+        gateway_id: gateway.id,
+        dashboard_id: dashboard.id
+      }
+
       %{valid?: validity} = CommandWidget.changeset(%CommandWidget{}, params)
       assert validity
     end
@@ -24,26 +30,38 @@ defmodule AcqdatCore.DashboardManagement.Schema.CommandWidgetTest do
     test "returns invalid for missing params" do
       params = %{}
       changeset = CommandWidget.changeset(%CommandWidget{}, params)
+
       assert errors_on(changeset) == %{
-        dashboard_id: ["can't be blank"],
-        gateway_id: ["can't be blank"],
-        label: ["can't be blank"],
-        module: ["can't be blank"]
-      }
+               dashboard_id: ["can't be blank"],
+               gateway_id: ["can't be blank"],
+               label: ["can't be blank"],
+               module: ["can't be blank"]
+             }
     end
 
     test "fails for invalid associations", context do
       %{dashboard: dashboard, gateway: gateway} = context
       module = "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl"
-      params = %{label: "LED CONTROL WIDGET", module: module,
-        gateway_id: -1, dashboard_id: dashboard.id}
+
+      params = %{
+        label: "LED CONTROL WIDGET",
+        module: module,
+        gateway_id: -1,
+        dashboard_id: dashboard.id
+      }
+
       changeset = CommandWidget.changeset(%CommandWidget{}, params)
 
       {:error, changeset} = Repo.insert(changeset)
       assert errors_on(changeset) == %{gateway: ["does not exist"]}
 
-      params = %{label: "LED CONTROL WIDGET", module: module,
-        gateway_id: gateway.id, dashboard_id: -1}
+      params = %{
+        label: "LED CONTROL WIDGET",
+        module: module,
+        gateway_id: gateway.id,
+        dashboard_id: -1
+      }
+
       changeset = CommandWidget.changeset(%CommandWidget{}, params)
 
       {:error, changeset} = Repo.insert(changeset)

--- a/apps/acqdat_core/test/dashboard_management/schema/command_widget_test.exs
+++ b/apps/acqdat_core/test/dashboard_management/schema/command_widget_test.exs
@@ -1,0 +1,53 @@
+defmodule AcqdatCore.DashboardManagement.Schema.CommandWidgetTest do
+  use ExUnit.Case, async: true
+  use AcqdatCore.DataCase
+  import AcqdatCore.Support.Factory
+  alias AcqdatCore.DashboardManagement.Schema.CommandWidget
+
+  describe "changeset" do
+    setup do
+      dashboard = insert(:dashboard)
+      gateway = insert(:gateway)
+
+      [gateway: gateway, dashboard: dashboard]
+    end
+
+    test "returns a valid changeset", context do
+      %{dashboard: dashboard, gateway: gateway} = context
+      module = "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl"
+      params = %{label: "LED CONTROL WIDGET", module: module,
+        gateway_id: gateway.id, dashboard_id: dashboard.id}
+      %{valid?: validity} = CommandWidget.changeset(%CommandWidget{}, params)
+      assert validity
+    end
+
+    test "returns invalid for missing params" do
+      params = %{}
+      changeset = CommandWidget.changeset(%CommandWidget{}, params)
+      assert errors_on(changeset) == %{
+        dashboard_id: ["can't be blank"],
+        gateway_id: ["can't be blank"],
+        label: ["can't be blank"],
+        module: ["can't be blank"]
+      }
+    end
+
+    test "fails for invalid associations", context do
+      %{dashboard: dashboard, gateway: gateway} = context
+      module = "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl"
+      params = %{label: "LED CONTROL WIDGET", module: module,
+        gateway_id: -1, dashboard_id: dashboard.id}
+      changeset = CommandWidget.changeset(%CommandWidget{}, params)
+
+      {:error, changeset} = Repo.insert(changeset)
+      assert errors_on(changeset) == %{gateway: ["does not exist"]}
+
+      params = %{label: "LED CONTROL WIDGET", module: module,
+        gateway_id: gateway.id, dashboard_id: -1}
+      changeset = CommandWidget.changeset(%CommandWidget{}, params)
+
+      {:error, changeset} = Repo.insert(changeset)
+      assert errors_on(changeset) == %{dashboard: ["does not exist"]}
+    end
+  end
+end

--- a/apps/acqdat_core/test/support/factory/factory.ex
+++ b/apps/acqdat_core/test/support/factory/factory.ex
@@ -12,6 +12,7 @@ defmodule AcqdatCore.Support.Factory do
   alias AcqdatCore.Widgets.Schema.{Widget, WidgetType}
   alias AcqdatCore.Schema.DigitalTwin
   alias AcqdatCore.Schema.IotManager.Gateway
+
   alias AcqdatCore.DashboardManagement.Schema.{
     Dashboard,
     WidgetInstance,

--- a/apps/acqdat_core/test/support/factory/factory.ex
+++ b/apps/acqdat_core/test/support/factory/factory.ex
@@ -12,7 +12,11 @@ defmodule AcqdatCore.Support.Factory do
   alias AcqdatCore.Widgets.Schema.{Widget, WidgetType}
   alias AcqdatCore.Schema.DigitalTwin
   alias AcqdatCore.Schema.IotManager.Gateway
-  alias AcqdatCore.DashboardManagement.Schema.{Dashboard, WidgetInstance}
+  alias AcqdatCore.DashboardManagement.Schema.{
+    Dashboard,
+    WidgetInstance,
+    CommandWidget
+  }
 
   alias AcqdatCore.Schema.EntityManagement.{
     Sensor,
@@ -100,6 +104,20 @@ defmodule AcqdatCore.Support.Factory do
       name: sequence(:dashboard_name, &"Dashboard#{&1}"),
       slug: sequence(:dashboard_name, &"Dashboard#{&1}"),
       org: build(:organisation)
+    }
+  end
+
+  def command_widget_factory() do
+    %CommandWidget{
+      uuid: UUID.uuid1(:hex),
+      label: "LED Control",
+      properties: %{},
+      module: "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl",
+      command_widget_type: "html",
+      gateway: build(:gateway),
+      dashboard: build(:dashboard),
+      data_settings: %{},
+      visual_settings: %{}
     }
   end
 

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -29,6 +29,18 @@ config :acqdat_iot, AcqdatIotWeb.Guardian,
   issuer: "acqdat_iot",
   secret_key: System.get_env("GUARDIAN_IOT_KEY")
 
+# AWS configuration for Image storage.
+config :arc,
+  asset_host: "https://datakrew-image.s3.ap-south-1.amazonaws.com",
+  storage: Arc.Storage.S3,
+  bucket: {:system, "AWS_S3_BUCKET"}
+
+# virtual_host: true
+config :ex_aws,
+  access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, :instance_role],
+  secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}, :instance_role],
+  region: "ap-south-1"
+
 config :acqdat_iot,
   app_port: app_iot_port
 


### PR DESCRIPTION
# Why
In order to send commands to a gateway, we need to show different command widgets on the dashboard. These command widgets are associated with a gateway. The user can interact with these widgets to send commands to a gateway which it can use for further control and processing.

## Changes
- Add Schema and Migration for command widgets.
- Add a command widget for LED Control Panel
- Add model functions for command widgets.
- Add controller functions for performing CRUD and sending commands to a gateway.