### PR TITLE
fixes: widget category inclusion in the dashboard show api: widgets list

### DIFF
--- a/apps/acqdat_api/lib/acqdat_api_web/views/dashboard_management/widget_instance_view.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/views/dashboard_management/widget_instance_view.ex
@@ -11,7 +11,8 @@ defmodule AcqdatApiWeb.DashboardManagement.WidgetInstanceView do
       series_data: render_many(widget.series_data, WidgetInstanceView, "series_data.json"),
       visual_properties: widget.visual_properties,
       series: widget.series,
-      widget_settings: widget.widget_settings
+      widget_settings: widget.widget_settings,
+      widget_category: widget.widget.category
     }
   end
 

--- a/apps/acqdat_core/lib/acqdat_core/entity-management/model/sensor_data.ex
+++ b/apps/acqdat_core/lib/acqdat_core/entity-management/model/sensor_data.ex
@@ -54,7 +54,7 @@ defmodule AcqdatCore.Model.EntityManagement.SensorData do
         cross_join: c in fragment("unnest(?)", data.parameters),
         where: fragment("?->>'uuid'=?", c, ^param_uuid),
         select: [
-          data.inserted_timestamp,
+          fragment("EXTRACT(EPOCH FROM ?)*1000", data.inserted_timestamp),
           fragment("?->>'value'", c)
         ]
       )

--- a/apps/acqdat_core/lib/acqdat_core/widgets/schema/vendors/highcharts.ex
+++ b/apps/acqdat_core/lib/acqdat_core/widgets/schema/vendors/highcharts.ex
@@ -443,7 +443,7 @@ defmodule AcqdatCore.Widgets.Schema.Vendors.HighCharts do
       q =
         (res || [])
         |> Enum.map(fn [a, b] ->
-          {DateTime.to_unix(a) * 1000, Float.parse(b) |> elem(0)}
+          {a, Float.parse(b) |> elem(0)}
         end)
         |> Map.new()
 


### PR DESCRIPTION
**Changes**
-> We need widget category, so that the widgets get categorised on the basis of these flags on dashboard
-> sensors's parameters fetch api to return data on the basis of sorted unix inserted_timestamps