### PR TITLE
Enhancements/dashboard panels

### DIFF
--- a/apps/acqdat_api/lib/acqdat_api/dashboard_management/dashboard.ex
+++ b/apps/acqdat_api/lib/acqdat_api/dashboard_management/dashboard.ex
@@ -12,16 +12,16 @@ defmodule AcqdatApi.DashboardManagement.Dashboard do
       name: name,
       description: description,
       org_id: org_id,
-      settings: settings,
-      widget_layouts: widget_layouts
+      avatar: avatar,
+      settings: settings
     } = attrs
 
     dashboard_params = %{
       name: name,
       description: description,
       org_id: org_id,
-      settings: settings,
-      widget_layouts: widget_layouts
+      avatar: avatar,
+      settings: settings
     }
 
     verify_dashboard(DashboardModel.create(dashboard_params))

--- a/apps/acqdat_api/lib/acqdat_api/dashboard_management/dashboard.ex
+++ b/apps/acqdat_api/lib/acqdat_api/dashboard_management/dashboard.ex
@@ -3,7 +3,7 @@ defmodule AcqdatApi.DashboardManagement.Dashboard do
   import AcqdatApiWeb.Helpers
 
   defdelegate get_all(data), to: DashboardModel
-  defdelegate get_with_widgets(dashboard_id), to: DashboardModel
+  defdelegate get_with_panels(dashboard_id), to: DashboardModel
   defdelegate update(dashboard, data), to: DashboardModel
   defdelegate delete(dashboard), to: DashboardModel
 

--- a/apps/acqdat_api/lib/acqdat_api/dashboard_management/dashboard.ex
+++ b/apps/acqdat_api/lib/acqdat_api/dashboard_management/dashboard.ex
@@ -1,6 +1,9 @@
 defmodule AcqdatApi.DashboardManagement.Dashboard do
-  alias AcqdatCore.Model.DashboardManagement.Dashboard, as: DashboardModel
   import AcqdatApiWeb.Helpers
+  alias Ecto.Multi
+  alias AcqdatCore.Repo
+  alias AcqdatCore.Model.DashboardManagement.Dashboard, as: DashboardModel
+  alias AcqdatCore.Model.DashboardManagement.Panel, as: PanelModel
 
   defdelegate get_all(data), to: DashboardModel
   defdelegate get_with_panels(dashboard_id), to: DashboardModel
@@ -24,14 +27,47 @@ defmodule AcqdatApi.DashboardManagement.Dashboard do
       settings: settings
     }
 
-    verify_dashboard(DashboardModel.create(dashboard_params))
+    create_dashboard(dashboard_params)
+  end
+
+  ############################# private functions ###########################
+
+  defp create_dashboard(params) do
+    Multi.new()
+    |> Multi.run(:create_dashboard, fn _, _changes ->
+      DashboardModel.create(params)
+    end)
+    |> Multi.run(:create_home_panel, fn _, %{create_dashboard: dashboard} ->
+      PanelModel.create(%{name: "Home", org_id: dashboard.org_id, dashboard_id: dashboard.id})
+    end)
+    |> run_transaction()
+  end
+
+  defp run_transaction(multi_query) do
+    result = Repo.transaction(multi_query)
+
+    case result do
+      {:ok, %{create_dashboard: dashboard, create_home_panel: _panel}} ->
+        verify_dashboard({:ok, dashboard})
+
+      {:error, failed_operation, failed_value, _changes_so_far} ->
+        case failed_operation do
+          :create_dashboard -> verify_error_changeset({:error, failed_value})
+          :create_home_panel -> verify_error_changeset({:error, failed_value})
+        end
+    end
   end
 
   defp verify_dashboard({:ok, dashboard}) do
+    dashboard = Repo.preload(dashboard, [:panels])
     {:ok, dashboard}
   end
 
   defp verify_dashboard({:error, dashboard}) do
     {:error, %{error: extract_changeset_error(dashboard)}}
+  end
+
+  defp verify_error_changeset({:error, changeset}) do
+    {:error, %{error: extract_changeset_error(changeset)}}
   end
 end

--- a/apps/acqdat_api/lib/acqdat_api/dashboard_management/dashboard.ex
+++ b/apps/acqdat_api/lib/acqdat_api/dashboard_management/dashboard.ex
@@ -24,7 +24,7 @@ defmodule AcqdatApi.DashboardManagement.Dashboard do
       description: description,
       org_id: org_id,
       avatar: avatar,
-      settings: settings
+      settings: settings || %{}
     }
 
     create_dashboard(dashboard_params)

--- a/apps/acqdat_api/lib/acqdat_api/dashboard_management/panel.ex
+++ b/apps/acqdat_api/lib/acqdat_api/dashboard_management/panel.ex
@@ -3,6 +3,9 @@ defmodule AcqdatApi.DashboardManagement.Panel do
   import AcqdatApiWeb.Helpers
 
   defdelegate get_all(data), to: PanelModel
+  defdelegate delete_all(ids), to: PanelModel
+  defdelegate get_with_widgets(panel_id), to: PanelModel
+  defdelegate update(panel, data), to: PanelModel
 
   def create(attrs) do
     %{

--- a/apps/acqdat_api/lib/acqdat_api/dashboard_management/panel.ex
+++ b/apps/acqdat_api/lib/acqdat_api/dashboard_management/panel.ex
@@ -1,0 +1,36 @@
+defmodule AcqdatApi.DashboardManagement.Panel do
+  alias AcqdatCore.Model.DashboardManagement.Panel, as: PanelModel
+  import AcqdatApiWeb.Helpers
+
+  defdelegate get_all(data), to: PanelModel
+
+  def create(attrs) do
+    %{
+      name: name,
+      description: description,
+      org_id: org_id,
+      dashboard_id: dashboard_id,
+      settings: settings,
+      widget_layouts: widget_layouts
+    } = attrs
+
+    panel_params = %{
+      name: name,
+      description: description,
+      org_id: org_id,
+      dashboard_id: dashboard_id,
+      settings: settings,
+      widget_layouts: widget_layouts
+    }
+
+    verify_panel(PanelModel.create(panel_params))
+  end
+
+  defp verify_panel({:ok, panel}) do
+    {:ok, panel}
+  end
+
+  defp verify_panel({:error, panel}) do
+    {:error, %{error: extract_changeset_error(panel)}}
+  end
+end

--- a/apps/acqdat_api/lib/acqdat_api/dashboard_management/widget_instance.ex
+++ b/apps/acqdat_api/lib/acqdat_api/dashboard_management/widget_instance.ex
@@ -26,7 +26,7 @@ defmodule AcqdatApi.DashboardManagement.WidgetInstance do
 
   defp widget_create_attrs(%{
          label: label,
-         dashboard_id: dashboard_id,
+         panel_id: panel_id,
          widget_id: widget_id,
          series_data: series_data,
          widget_settings: widget_settings,
@@ -34,7 +34,7 @@ defmodule AcqdatApi.DashboardManagement.WidgetInstance do
        }) do
     %{
       label: label,
-      dashboard_id: dashboard_id,
+      panel_id: panel_id,
       widget_id: widget_id,
       series_data: series_data,
       widget_settings: widget_settings,

--- a/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/command_widget_controller.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/command_widget_controller.ex
@@ -4,7 +4,7 @@ defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetController do
   import AcqdatApiWeb.Helpers
   alias AcqdatApi.DashboardManagement.CommandWidget
 
-  plug AcqdatApiWeb.Plug.LoadDashboard when action not in [:command_widget_types]
+  plug AcqdatApiWeb.Plug.LoadPanel when action not in [:command_widget_types]
   plug AcqdatApiWeb.Plug.CommandWidget when action in [:update, :delete]
 
   def command_widget_types(conn, _params) do

--- a/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/dashboard_controller.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/dashboard_controller.ex
@@ -37,7 +37,7 @@ defmodule AcqdatApiWeb.DashboardManagement.DashboardController do
              {:create, {:ok, dashboard}} <- {:create, Dashboard.create(data)} do
           conn
           |> put_status(200)
-          |> render("dashboard.json", %{dashboard: dashboard})
+          |> render("show.json", %{dashboard: dashboard})
         else
           {:extract, {:error, error}} ->
             send_error(conn, 400, error)

--- a/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/dashboard_controller.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/dashboard_controller.ex
@@ -54,7 +54,7 @@ defmodule AcqdatApiWeb.DashboardManagement.DashboardController do
       nil ->
         {id, _} = Integer.parse(id)
 
-        case Dashboard.get_with_widgets(id) do
+        case Dashboard.get_with_panels(id) do
           {:error, message} ->
             send_error(conn, 400, message)
 

--- a/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/dashboard_controller.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/dashboard_controller.ex
@@ -3,6 +3,8 @@ defmodule AcqdatApiWeb.DashboardManagement.DashboardController do
   import AcqdatApiWeb.Helpers
   import AcqdatApiWeb.Validators.DashboardManagement.Dashboard
   alias AcqdatApi.DashboardManagement.Dashboard
+  alias AcqdatApi.Image
+  alias AcqdatApi.ImageDeletion
 
   plug AcqdatApiWeb.Plug.LoadOrg
   plug AcqdatApiWeb.Plug.LoadDashboard when action in [:update, :delete]
@@ -28,6 +30,7 @@ defmodule AcqdatApiWeb.DashboardManagement.DashboardController do
   def create(conn, params) do
     case conn.status do
       nil ->
+        params = add_avatar_to_params(conn, params)
         changeset = verify_create(params)
 
         with {:extract, {:ok, data}} <- {:extract, extract_changeset_data(changeset)},
@@ -73,7 +76,11 @@ defmodule AcqdatApiWeb.DashboardManagement.DashboardController do
   def update(conn, params) do
     case conn.status do
       nil ->
-        case Dashboard.update(conn.assigns.dashboard, params) do
+        dashboard = conn.assigns.dashboard
+        params = Map.put(params, "avatar", dashboard.avatar)
+        params = extract_image(conn, dashboard, params)
+
+        case Dashboard.update(dashboard, params) do
           {:ok, dashboard} ->
             conn
             |> put_status(200)
@@ -101,6 +108,10 @@ defmodule AcqdatApiWeb.DashboardManagement.DashboardController do
       nil ->
         case Dashboard.delete(conn.assigns.dashboard) do
           {:ok, dashboard} ->
+            if dashboard.avatar != nil do
+              ImageDeletion.delete_operation(dashboard.avatar, "dashboard")
+            end
+
             conn
             |> put_status(200)
             |> render("dashboard.json", %{dashboard: dashboard})
@@ -119,6 +130,42 @@ defmodule AcqdatApiWeb.DashboardManagement.DashboardController do
       404 ->
         conn
         |> send_error(404, "Resource Not Found")
+    end
+  end
+
+  ############################# private functions ###########################
+
+  defp add_avatar_to_params(conn, params) do
+    params = Map.put(params, "avatar", "")
+
+    case is_nil(params["image"]) do
+      true ->
+        params
+
+      false ->
+        add_image_url(conn, params)
+    end
+  end
+
+  defp extract_image(conn, dashboard, params) do
+    case is_nil(params["image"]) do
+      true ->
+        params
+
+      false ->
+        if dashboard.avatar != nil do
+          ImageDeletion.delete_operation(dashboard.avatar, "dashboard")
+        end
+
+        add_image_url(conn, params)
+    end
+  end
+
+  defp add_image_url(conn, %{"image" => image} = params) do
+    with {:ok, image_name} <- Image.store({image, "dashboard"}) do
+      Map.replace!(params, "avatar", Image.url({image_name, "dashboard"}))
+    else
+      {:error, error} -> send_error(conn, 400, error)
     end
   end
 end

--- a/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/panel_controller.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/panel_controller.ex
@@ -5,7 +5,7 @@ defmodule AcqdatApiWeb.DashboardManagement.PanelController do
   alias AcqdatApi.DashboardManagement.Panel
 
   plug AcqdatApiWeb.Plug.LoadOrg
-  # plug AcqdatApiWeb.Plug.LoadDashboard when action in [:update, :delete]
+  plug AcqdatApiWeb.Plug.LoadPanel when action in [:update]
 
   def index(conn, params) do
     changeset = verify_index_params(params)
@@ -49,76 +49,68 @@ defmodule AcqdatApiWeb.DashboardManagement.PanelController do
     end
   end
 
-  # def show(conn, %{"id" => id}) do
-  #   case conn.status do
-  #     nil ->
-  #       {id, _} = Integer.parse(id)
+  def show(conn, %{"id" => id}) do
+    case conn.status do
+      nil ->
+        {id, _} = Integer.parse(id)
 
-  #       case Dashboard.get_with_widgets(id) do
-  #         {:error, message} ->
-  #           send_error(conn, 400, message)
+        case Panel.get_with_widgets(id) do
+          {:error, message} ->
+            send_error(conn, 400, message)
 
-  #         {:ok, dashboard} ->
-  #           conn
-  #           |> put_status(200)
-  #           |> render("show.json", %{dashboard: dashboard})
-  #       end
+          {:ok, panel} ->
+            conn
+            |> put_status(200)
+            |> render("show.json", %{panel: panel})
+        end
 
-  #     404 ->
-  #       conn
-  #       |> send_error(404, "Resource Not Found")
-  #   end
-  # end
+      404 ->
+        conn
+        |> send_error(404, "Resource Not Found")
+    end
+  end
 
-  # def update(conn, params) do
-  #   case conn.status do
-  #     nil ->
-  #       case Dashboard.update(conn.assigns.dashboard, params) do
-  #         {:ok, dashboard} ->
-  #           conn
-  #           |> put_status(200)
-  #           |> render("dashboard.json", %{dashboard: dashboard})
+  def update(conn, params) do
+    case conn.status do
+      nil ->
+        case Panel.update(conn.assigns.panel, params) do
+          {:ok, panel} ->
+            conn
+            |> put_status(200)
+            |> render("panel.json", %{panel: panel})
 
-  #         {:error, dashboard} ->
-  #           error =
-  #             case String.valid?(dashboard) do
-  #               false -> extract_changeset_error(dashboard)
-  #               true -> dashboard
-  #             end
+          {:error, panel} ->
+            error =
+              case String.valid?(panel) do
+                false -> extract_changeset_error(panel)
+                true -> panel
+              end
 
-  #           conn
-  #           |> send_error(400, error)
-  #       end
+            conn
+            |> send_error(400, error)
+        end
 
-  #     404 ->
-  #       conn
-  #       |> send_error(404, "Resource Not Found")
-  #   end
-  # end
+      404 ->
+        conn
+        |> send_error(404, "Resource Not Found")
+    end
+  end
 
-  # def delete(conn, _params) do
-  #   case conn.status do
-  #     nil ->
-  #       case Dashboard.delete(conn.assigns.dashboard) do
-  #         {:ok, dashboard} ->
-  #           conn
-  #           |> put_status(200)
-  #           |> render("dashboard.json", %{dashboard: dashboard})
+  def delete(conn, %{"ids" => ids}) do
+    case conn.status do
+      nil ->
+        case Panel.delete_all(ids) do
+          {no_of_records, _} ->
+            conn
+            |> put_status(200)
+            |> render("delete_all.json",
+              message: "#{no_of_records} number of panels deleted successfully"
+            )
+        end
 
-  #         {:error, dashboard} ->
-  #           error =
-  #             case String.valid?(dashboard) do
-  #               false -> extract_changeset_error(dashboard)
-  #               true -> dashboard
-  #             end
-
-  #           conn
-  #           |> send_error(400, error)
-  #       end
-
-  #     404 ->
-  #       conn
-  #       |> send_error(404, "Resource Not Found")
-  #   end
-  # end
+      404 ->
+        conn
+        |> send_error(404, "Resource Not Found")
+    end
+  end
 end

--- a/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/panel_controller.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/panel_controller.ex
@@ -1,0 +1,124 @@
+defmodule AcqdatApiWeb.DashboardManagement.PanelController do
+  use AcqdatApiWeb, :controller
+  import AcqdatApiWeb.Helpers
+  import AcqdatApiWeb.Validators.DashboardManagement.Panel
+  alias AcqdatApi.DashboardManagement.Panel
+
+  plug AcqdatApiWeb.Plug.LoadOrg
+  # plug AcqdatApiWeb.Plug.LoadDashboard when action in [:update, :delete]
+
+  def index(conn, params) do
+    changeset = verify_index_params(params)
+
+    case conn.status do
+      nil ->
+        {:extract, {:ok, data}} = {:extract, extract_changeset_data(changeset)}
+        {:list, panels} = {:list, Panel.get_all(data)}
+
+        conn
+        |> put_status(200)
+        |> render("index.json", panels)
+
+      404 ->
+        conn
+        |> send_error(404, "Resource Not Found")
+    end
+  end
+
+  def create(conn, params) do
+    case conn.status do
+      nil ->
+        changeset = verify_create(params)
+
+        with {:extract, {:ok, data}} <- {:extract, extract_changeset_data(changeset)},
+             {:create, {:ok, panel}} <- {:create, Panel.create(data)} do
+          conn
+          |> put_status(200)
+          |> render("panel.json", %{panel: panel})
+        else
+          {:extract, {:error, error}} ->
+            send_error(conn, 400, error)
+
+          {:create, {:error, message}} ->
+            send_error(conn, 400, message)
+        end
+
+      404 ->
+        conn
+        |> send_error(404, "Resource Not Found")
+    end
+  end
+
+  # def show(conn, %{"id" => id}) do
+  #   case conn.status do
+  #     nil ->
+  #       {id, _} = Integer.parse(id)
+
+  #       case Dashboard.get_with_widgets(id) do
+  #         {:error, message} ->
+  #           send_error(conn, 400, message)
+
+  #         {:ok, dashboard} ->
+  #           conn
+  #           |> put_status(200)
+  #           |> render("show.json", %{dashboard: dashboard})
+  #       end
+
+  #     404 ->
+  #       conn
+  #       |> send_error(404, "Resource Not Found")
+  #   end
+  # end
+
+  # def update(conn, params) do
+  #   case conn.status do
+  #     nil ->
+  #       case Dashboard.update(conn.assigns.dashboard, params) do
+  #         {:ok, dashboard} ->
+  #           conn
+  #           |> put_status(200)
+  #           |> render("dashboard.json", %{dashboard: dashboard})
+
+  #         {:error, dashboard} ->
+  #           error =
+  #             case String.valid?(dashboard) do
+  #               false -> extract_changeset_error(dashboard)
+  #               true -> dashboard
+  #             end
+
+  #           conn
+  #           |> send_error(400, error)
+  #       end
+
+  #     404 ->
+  #       conn
+  #       |> send_error(404, "Resource Not Found")
+  #   end
+  # end
+
+  # def delete(conn, _params) do
+  #   case conn.status do
+  #     nil ->
+  #       case Dashboard.delete(conn.assigns.dashboard) do
+  #         {:ok, dashboard} ->
+  #           conn
+  #           |> put_status(200)
+  #           |> render("dashboard.json", %{dashboard: dashboard})
+
+  #         {:error, dashboard} ->
+  #           error =
+  #             case String.valid?(dashboard) do
+  #               false -> extract_changeset_error(dashboard)
+  #               true -> dashboard
+  #             end
+
+  #           conn
+  #           |> send_error(400, error)
+  #       end
+
+  #     404 ->
+  #       conn
+  #       |> send_error(404, "Resource Not Found")
+  #   end
+  # end
+end

--- a/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/widget_instance_controller.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/widget_instance_controller.ex
@@ -5,7 +5,7 @@ defmodule AcqdatApiWeb.DashboardManagement.WidgetInstanceController do
   alias AcqdatApi.DashboardManagement.WidgetInstance
 
   plug AcqdatApiWeb.Plug.LoadOrg
-  plug AcqdatApiWeb.Plug.LoadDashboard
+  plug AcqdatApiWeb.Plug.LoadPanel
   plug AcqdatApiWeb.Plug.LoadWidget
   plug AcqdatApiWeb.Plug.LoadWidgetInstance when action in [:update, :delete]
 

--- a/apps/acqdat_api/lib/acqdat_api_web/plugs/load_panel.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/plugs/load_panel.ex
@@ -1,0 +1,34 @@
+defmodule AcqdatApiWeb.Plug.LoadPanel do
+  import Plug.Conn
+  alias AcqdatCore.Model.DashboardManagement.Panel, as: PanelModel
+
+  @spec init(any) :: any
+  def init(default), do: default
+
+  @spec call(Plug.Conn.t(), any) :: Plug.Conn.t()
+  def call(%{params: %{"panel_id" => panel_id}} = conn, _params) do
+    check_panel(conn, panel_id)
+  end
+
+  def call(%{params: %{"id" => panel_id}} = conn, _params) do
+    check_panel(conn, panel_id)
+  end
+
+  defp check_panel(conn, panel_id) do
+    case Integer.parse(panel_id) do
+      {panel_id, _} ->
+        case PanelModel.get_by_id(panel_id) do
+          {:ok, panel} ->
+            assign(conn, :panel, panel)
+
+          {:error, _message} ->
+            conn
+            |> put_status(404)
+        end
+
+      :error ->
+        conn
+        |> put_status(404)
+    end
+  end
+end

--- a/apps/acqdat_api/lib/acqdat_api_web/router.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/router.ex
@@ -118,6 +118,7 @@ defmodule AcqdatApiWeb.Router do
 
     scope "/dashboards/:dashboard_id", DashboardManagement do
       resources "/command_widgets", CommandWidgetController, except: [:new, :index, :edit]
+      resources "/panels", PanelController, except: [:new, :edit]
     end
 
     get "/command_widget_types",

--- a/apps/acqdat_api/lib/acqdat_api_web/router.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/router.ex
@@ -117,30 +117,34 @@ defmodule AcqdatApiWeb.Router do
     resources "/dashboards", DashboardManagement.DashboardController, except: [:new, :edit]
 
     scope "/dashboards/:dashboard_id", DashboardManagement do
+      resources "/panels", PanelController, except: [:new, :edit, :delete]
+      delete "/panels", PanelController, :delete, as: :panel
+    end
+
+    scope "/panels/:panel_id", DashboardManagement do
       resources "/command_widgets", CommandWidgetController, except: [:new, :index, :edit]
-      resources "/panels", PanelController, except: [:new, :edit]
     end
 
     get "/command_widget_types",
         DashboardManagement.CommandWidgetController,
         :command_widget_types
 
-    post "/dashboards/:dashboard_id/widgets/:widget_id/widget_instances",
+    post "/panels/:panel_id/widgets/:widget_id/widget_instances",
          DashboardManagement.WidgetInstanceController,
          :create,
          as: :create_widget_instances
 
-    get "/dashboards/:dashboard_id/widgets/:widget_id/widget_instances/:id",
+    get "/panels/:panel_id/widgets/:widget_id/widget_instances/:id",
         DashboardManagement.WidgetInstanceController,
         :show,
         as: :show_widget_instances
 
-    delete "/dashboards/:dashboard_id/widgets/:widget_id/widget_instances/:id",
+    delete "/panels/:panel_id/widgets/:widget_id/widget_instances/:id",
            DashboardManagement.WidgetInstanceController,
            :delete,
            as: :delete_widget_instances
 
-    put "/dashboards/:dashboard_id/widgets/:widget_id/widget_instances/:id",
+    put "/panels/:panel_id/widgets/:widget_id/widget_instances/:id",
         DashboardManagement.WidgetInstanceController,
         :update,
         as: :update_widget_instances

--- a/apps/acqdat_api/lib/acqdat_api_web/validators/dashboard_management/command_widget.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/validators/dashboard_management/command_widget.ex
@@ -10,7 +10,7 @@ defmodule AcqdatApiWeb.Validators.DashboardManagement.CommandWidget do
       visual_settings: :map,
       properties: :map,
       gateway_id!: :integer,
-      dashboard_id!: :integer
+      panel_id!: :integer
     })
   )
 end

--- a/apps/acqdat_api/lib/acqdat_api_web/validators/dashboard_management/dashboard.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/validators/dashboard_management/dashboard.ex
@@ -13,6 +13,7 @@ defmodule AcqdatApiWeb.Validators.DashboardManagement.Dashboard do
     verify_create(%{
       org_id!: :integer,
       name!: :string,
+      avatar: :string,
       description: :string,
       settings: :map,
       widget_layouts: :map

--- a/apps/acqdat_api/lib/acqdat_api_web/validators/dashboard_management/panel.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/validators/dashboard_management/panel.ex
@@ -1,0 +1,23 @@
+defmodule AcqdatApiWeb.Validators.DashboardManagement.Panel do
+  use Params
+
+  defparams(
+    verify_index_params(%{
+      page_size: :integer,
+      page_number: :integer,
+      org_id!: :integer,
+      dashboard_id!: :integer
+    })
+  )
+
+  defparams(
+    verify_create(%{
+      org_id!: :integer,
+      dashboard_id!: :integer,
+      name!: :string,
+      description: :string,
+      settings: :map,
+      widget_layouts: :map
+    })
+  )
+end

--- a/apps/acqdat_api/lib/acqdat_api_web/validators/dashboard_management/widget_instance.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/validators/dashboard_management/widget_instance.ex
@@ -6,7 +6,7 @@ defmodule AcqdatApiWeb.Validators.DashboardManagement.WidgetInstance do
       label!: :string,
       org_id!: :integer,
       widget_id!: :integer,
-      dashboard_id!: :integer,
+      panel_id!: :integer,
       widget_settings: :map,
       visual_properties: :map,
       series_data: [field: {:array, :map}, default: []]

--- a/apps/acqdat_api/lib/acqdat_api_web/views/dashboard_management/command_widget_view.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/views/dashboard_management/command_widget_view.ex
@@ -23,7 +23,7 @@ defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetView do
       id: command_widget.id,
       uuid: command_widget.uuid,
       gateway_id: command_widget.gateway_id,
-      dashboard_id: command_widget.dashboard_id,
+      panel_id: command_widget.panel_id,
       label: command_widget.label,
       data_settings: command_widget.data_settings,
       visual_settings: command_widget.visual_settings,

--- a/apps/acqdat_api/lib/acqdat_api_web/views/dashboard_management/dashboard_view.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/views/dashboard_management/dashboard_view.ex
@@ -12,7 +12,7 @@ defmodule AcqdatApiWeb.DashboardManagement.DashboardView do
       slug: dashboard.slug,
       uuid: dashboard.uuid,
       settings: dashboard.settings,
-      widget_layouts: dashboard.widget_layouts
+      avatar: dashboard.avatar
     }
   end
 
@@ -35,6 +35,7 @@ defmodule AcqdatApiWeb.DashboardManagement.DashboardView do
       slug: dashboard.slug,
       uuid: dashboard.uuid,
       settings: dashboard.settings,
+      avatar: dashboard.avatar,
       panels: render_many(dashboard.panels, PanelView, "panel.json")
     }
   end

--- a/apps/acqdat_api/lib/acqdat_api_web/views/dashboard_management/dashboard_view.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/views/dashboard_management/dashboard_view.ex
@@ -1,8 +1,7 @@
 defmodule AcqdatApiWeb.DashboardManagement.DashboardView do
   use AcqdatApiWeb, :view
   alias AcqdatApiWeb.DashboardManagement.DashboardView
-  alias AcqdatApiWeb.DashboardManagement.WidgetInstanceView
-  alias AcqdatApiWeb.DashboardManagement.CommandWidgetView
+  alias AcqdatApiWeb.DashboardManagement.PanelView
 
   def render("dashboard.json", %{dashboard: dashboard}) do
     %{
@@ -36,9 +35,7 @@ defmodule AcqdatApiWeb.DashboardManagement.DashboardView do
       slug: dashboard.slug,
       uuid: dashboard.uuid,
       settings: dashboard.settings,
-      widget_layouts: dashboard.widget_layouts,
-      widgets: render_many(dashboard.widgets, WidgetInstanceView, "show.json"),
-      command_widgets: render_many(dashboard.command_widgets, CommandWidgetView, "show.json")
+      panels: render_many(dashboard.panels, PanelView, "panel.json")
     }
   end
 end

--- a/apps/acqdat_api/lib/acqdat_api_web/views/dashboard_management/dashboard_view.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/views/dashboard_management/dashboard_view.ex
@@ -11,7 +11,7 @@ defmodule AcqdatApiWeb.DashboardManagement.DashboardView do
       org_id: dashboard.org_id,
       slug: dashboard.slug,
       uuid: dashboard.uuid,
-      settings: dashboard.settings,
+      settings: render_one(dashboard.settings, DashboardView, "settings.json"),
       avatar: dashboard.avatar
     }
   end
@@ -34,9 +34,18 @@ defmodule AcqdatApiWeb.DashboardManagement.DashboardView do
       org_id: dashboard.org_id,
       slug: dashboard.slug,
       uuid: dashboard.uuid,
-      settings: dashboard.settings,
+      settings: render_one(dashboard.settings, DashboardView, "settings.json"),
       avatar: dashboard.avatar,
       panels: render_many(dashboard.panels, PanelView, "panel.json")
+    }
+  end
+
+  def render("settings.json", %{dashboard: settings}) do
+    %{
+      id: settings.id,
+      background_color: settings.background_color,
+      client_name: settings.client_name,
+      sidebar_color: settings.sidebar_color
     }
   end
 end

--- a/apps/acqdat_api/lib/acqdat_api_web/views/dashboard_management/panel.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/views/dashboard_management/panel.ex
@@ -1,0 +1,28 @@
+defmodule AcqdatApiWeb.DashboardManagement.PanelView do
+  use AcqdatApiWeb, :view
+  alias AcqdatApiWeb.DashboardManagement.PanelView
+
+  def render("panel.json", %{panel: panel}) do
+    %{
+      id: panel.id,
+      name: panel.name,
+      description: panel.description,
+      org_id: panel.org_id,
+      dashboard_id: panel.dashboard_id,
+      slug: panel.slug,
+      uuid: panel.uuid,
+      settings: panel.settings,
+      widget_layouts: panel.widget_layouts
+    }
+  end
+
+  def render("index.json", panels) do
+    %{
+      panels: render_many(panels.entries, PanelView, "panel.json"),
+      page_number: panels.page_number,
+      page_size: panels.page_size,
+      total_entries: panels.total_entries,
+      total_pages: panels.total_pages
+    }
+  end
+end

--- a/apps/acqdat_api/lib/acqdat_api_web/views/dashboard_management/panel_view.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/views/dashboard_management/panel_view.ex
@@ -1,6 +1,14 @@
 defmodule AcqdatApiWeb.DashboardManagement.PanelView do
   use AcqdatApiWeb, :view
   alias AcqdatApiWeb.DashboardManagement.PanelView
+  alias AcqdatApiWeb.DashboardManagement.WidgetInstanceView
+  alias AcqdatApiWeb.DashboardManagement.CommandWidgetView
+
+  def render("delete_all.json", %{message: message}) do
+    %{
+      status: message
+    }
+  end
 
   def render("panel.json", %{panel: panel}) do
     %{
@@ -23,6 +31,22 @@ defmodule AcqdatApiWeb.DashboardManagement.PanelView do
       page_size: panels.page_size,
       total_entries: panels.total_entries,
       total_pages: panels.total_pages
+    }
+  end
+
+  def render("show.json", %{panel: panel}) do
+    %{
+      id: panel.id,
+      name: panel.name,
+      description: panel.description,
+      org_id: panel.org_id,
+      dashboard_id: panel.dashboard_id,
+      slug: panel.slug,
+      uuid: panel.uuid,
+      settings: panel.settings,
+      widget_layouts: panel.widget_layouts,
+      widgets: render_many(panel.widgets, WidgetInstanceView, "show.json"),
+      command_widgets: render_many(panel.command_widgets, CommandWidgetView, "show.json")
     }
   end
 end

--- a/apps/acqdat_api/test/acqdat_api_web/controllers/dashboard-management/command_widget_controller_test.exs
+++ b/apps/acqdat_api/test/acqdat_api_web/controllers/dashboard-management/command_widget_controller_test.exs
@@ -29,20 +29,20 @@ defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetControllerTest do
 
     setup do
       org = insert(:organisation)
-      dashboard = insert(:dashboard, org: org)
+      panel = insert(:panel, org: org)
       gateway = insert(:gateway, org: org)
 
-      [gateway: gateway, dashboard: dashboard, org: org]
+      [gateway: gateway, panel: panel, org: org]
     end
 
     test "creates a command widget", context do
-      %{gateway: gateway, dashboard: dashboard, conn: conn, org: org} = context
+      %{gateway: gateway, panel: panel, conn: conn, org: org} = context
       module = "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl"
       data_settings = setup_data()
 
       params = %{
         "gateway_id" => gateway.id,
-        "dashboard_id" => dashboard.id,
+        "panel_id" => panel.id,
         "module" => module,
         "data_settings" => data_settings,
         "visual_settings" => %{},
@@ -52,7 +52,7 @@ defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetControllerTest do
       result =
         conn
         |> post(
-          Routes.command_widget_path(conn, :create, org.id, dashboard.id),
+          Routes.command_widget_path(conn, :create, org.id, panel.id),
           params
         )
         |> json_response(200)
@@ -62,13 +62,13 @@ defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetControllerTest do
     end
 
     test "fails if error", context do
-      %{dashboard: dashboard, conn: conn, org: org} = context
+      %{panel: panel, conn: conn, org: org} = context
       module = "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl"
       data_settings = setup_data()
 
       params = %{
         "gateway_id" => -1,
-        "dashboard_id" => dashboard.id,
+        "panel_id" => panel.id,
         "module" => module,
         "data_settings" => data_settings,
         "visual_settings" => %{},
@@ -78,7 +78,7 @@ defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetControllerTest do
       result =
         conn
         |> post(
-          Routes.command_widget_path(conn, :create, org.id, dashboard.id),
+          Routes.command_widget_path(conn, :create, org.id, panel.id),
           params
         )
         |> json_response(400)
@@ -92,14 +92,14 @@ defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetControllerTest do
 
     setup do
       org = insert(:organisation)
-      dashboard = insert(:dashboard, org: org)
+      panel = insert(:panel, org: org)
       gateway = insert(:gateway, org: org)
 
-      [gateway: gateway, dashboard: dashboard, org: org]
+      [gateway: gateway, panel: panel, org: org]
     end
 
     test "update data settings", context do
-      %{dashboard: dashboard, conn: conn, org: org} = context
+      %{panel: panel, conn: conn, org: org} = context
       command_widget = insert(:command_widget)
       data_settings = setup_data()
       params = %{"data_settings" => data_settings}
@@ -107,7 +107,7 @@ defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetControllerTest do
       result =
         put(
           conn,
-          Routes.command_widget_path(conn, :update, org.id, dashboard.id, command_widget.id),
+          Routes.command_widget_path(conn, :update, org.id, panel.id, command_widget.id),
           params
         )
         |> json_response(200)
@@ -121,18 +121,18 @@ defmodule AcqdatApiWeb.DashboardManagement.CommandWidgetControllerTest do
 
     setup do
       org = insert(:organisation)
-      dashboard = insert(:dashboard, org: org)
+      panel = insert(:panel, org: org)
 
-      [dashboard: dashboard, org: org]
+      [panel: panel, org: org]
     end
 
     test "deletes a command widget", context do
-      %{org: org, dashboard: dashboard, conn: conn} = context
+      %{org: org, panel: panel, conn: conn} = context
       command_widget = insert(:command_widget)
 
       delete(
         conn,
-        Routes.command_widget_path(conn, :delete, org.id, dashboard.id, command_widget.id)
+        Routes.command_widget_path(conn, :delete, org.id, panel.id, command_widget.id)
       )
       |> json_response(200)
 

--- a/apps/acqdat_api/test/acqdat_api_web/controllers/dashboard-management/panel_controller_test.exs
+++ b/apps/acqdat_api/test/acqdat_api_web/controllers/dashboard-management/panel_controller_test.exs
@@ -1,0 +1,322 @@
+defmodule AcqdatApiWeb.DashboardManagement.PanelControllerTest do
+  use ExUnit.Case, async: true
+  use AcqdatApiWeb.ConnCase
+  use AcqdatCore.DataCase
+  import AcqdatCore.Support.Factory
+
+  describe "show/2" do
+    setup :setup_conn
+
+    setup do
+      panel = insert(:panel)
+
+      [panel: panel]
+    end
+
+    test "fails if invalid token in authorization header", %{conn: conn} do
+      bad_access_token = "qwerty1234567qwerty12"
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{bad_access_token}")
+
+      params = %{
+        id: 3
+      }
+
+      conn = get(conn, Routes.panel_path(conn, :show, 1, 1, params.id))
+      result = conn |> json_response(403)
+      assert result == %{"errors" => %{"message" => "Unauthorized"}}
+    end
+
+    test "panel with invalid panel id", %{conn: conn, panel: panel} do
+      params = %{
+        id: -1
+      }
+
+      conn =
+        get(
+          conn,
+          Routes.panel_path(conn, :show, panel.org_id, panel.dashboard_id, params.id)
+        )
+
+      result = conn |> json_response(400)
+      assert result == %{"errors" => %{"message" => "panel with this id not found"}}
+    end
+
+    test "panel with valid id", %{conn: conn, panel: panel} do
+      conn =
+        get(
+          conn,
+          Routes.panel_path(conn, :show, panel.org_id, panel.dashboard_id, panel.id)
+        )
+
+      result = conn |> json_response(200)
+
+      refute is_nil(result)
+
+      assert Map.has_key?(result, "id")
+      assert Map.has_key?(result, "name")
+    end
+  end
+
+  describe "update/2" do
+    setup :setup_conn
+
+    setup do
+      panel = insert(:panel)
+
+      [panel: panel]
+    end
+
+    test "panel update", %{conn: conn, panel: panel} do
+      data = %{
+        name: "updated panel name"
+      }
+
+      conn =
+        put(
+          conn,
+          Routes.panel_path(
+            conn,
+            :update,
+            panel.org_id,
+            panel.dashboard_id,
+            panel.id
+          ),
+          data
+        )
+
+      response = conn |> json_response(200)
+
+      assert Map.has_key?(response, "name")
+      assert Map.has_key?(response, "id")
+      assert response["name"] == "updated panel name"
+    end
+
+    test "fails if invalid token in authorization header", %{conn: conn} do
+      bad_access_token = "qwerty1234567qwerty12"
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{bad_access_token}")
+
+      params = %{
+        id: 3
+      }
+
+      conn = put(conn, Routes.panel_path(conn, :update, 1, 1, params.id))
+      result = conn |> json_response(403)
+      assert result == %{"errors" => %{"message" => "Unauthorized"}}
+    end
+
+    test "panel with invalid panel id", %{conn: conn, panel: panel} do
+      params = %{
+        id: -1
+      }
+
+      conn =
+        put(
+          conn,
+          Routes.panel_path(conn, :update, panel.org_id, panel.dashboard_id, params.id)
+        )
+
+      result = conn |> json_response(404)
+      assert result == %{"errors" => %{"message" => "Resource Not Found"}}
+    end
+  end
+
+  describe "delete/2" do
+    setup :setup_conn
+
+    setup do
+      panel = insert(:panel)
+
+      [panel: panel]
+    end
+
+    test "panel delete", %{conn: conn, panel: panel} do
+      params = %{
+        ids: [panel.id]
+      }
+
+      conn =
+        delete(
+          conn,
+          Routes.panel_path(
+            conn,
+            :delete,
+            panel.org_id,
+            panel.dashboard_id,
+            params
+          )
+        )
+
+      response = conn |> json_response(200)
+
+      assert response == %{"status" => "1 number of panels deleted successfully"}
+    end
+
+    test "fails if invalid token in authorization header", %{conn: conn} do
+      bad_access_token = "qwerty1234567qwerty12"
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{bad_access_token}")
+
+      params = %{
+        ids: [1]
+      }
+
+      conn = delete(conn, Routes.panel_path(conn, :delete, 1, 1, params))
+      result = conn |> json_response(403)
+      assert result == %{"errors" => %{"message" => "Unauthorized"}}
+    end
+
+    test "panel with invalid panel id", %{conn: conn, panel: panel} do
+      params = %{
+        ids: [-1]
+      }
+
+      conn = delete(conn, Routes.panel_path(conn, :delete, 1, panel.dashboard_id, params))
+
+      result = conn |> json_response(404)
+      assert result == %{"errors" => %{"message" => "Resource Not Found"}}
+    end
+  end
+
+  describe "create/2" do
+    setup :setup_conn
+
+    test "panel type create", %{conn: conn} do
+      panel_manifest = build(:panel)
+      org = insert(:organisation)
+      dashboard = insert(:dashboard)
+
+      data = %{
+        name: panel_manifest.name
+      }
+
+      conn = post(conn, Routes.panel_path(conn, :create, org.id, dashboard.id), data)
+      response = conn |> json_response(200)
+      assert Map.has_key?(response, "name")
+      assert Map.has_key?(response, "id")
+    end
+
+    test "fails if authorization header not found", %{conn: conn} do
+      bad_access_token = "qwerty1234567uiop"
+      org = insert(:organisation)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{bad_access_token}")
+
+      data = %{}
+      conn = post(conn, Routes.panel_path(conn, :create, org.id, 1), data)
+      result = conn |> json_response(403)
+      assert result == %{"errors" => %{"message" => "Unauthorized"}}
+    end
+
+    test "fails if required params are missing", %{conn: conn} do
+      org = insert(:organisation)
+      dashboard = insert(:dashboard)
+
+      data = %{}
+
+      conn = post(conn, Routes.panel_path(conn, :create, org.id, dashboard.id), data)
+
+      response = conn |> json_response(400)
+
+      assert response == %{
+               "errors" => %{
+                 "message" => %{
+                   "name" => ["can't be blank"]
+                 }
+               }
+             }
+    end
+  end
+
+  describe "index/2" do
+    setup :setup_conn
+
+    test "fetch all panels", %{conn: conn} do
+      panel = insert(:panel)
+
+      params = %{
+        "page_size" => 100,
+        "page_number" => 1
+      }
+
+      conn =
+        get(
+          conn,
+          Routes.panel_path(conn, :index, panel.org_id, panel.dashboard_id, params)
+        )
+
+      response = conn |> json_response(200)
+
+      assert length(response["panels"]) == 1
+      assertion_panel = List.first(response["panels"])
+      assert assertion_panel["id"] == panel.id
+      assert assertion_panel["name"] == panel.name
+    end
+
+    test "if params are missing", %{conn: conn} do
+      panel = insert(:panel)
+
+      conn =
+        get(
+          conn,
+          Routes.panel_path(conn, :index, panel.org_id, panel.dashboard_id, %{})
+        )
+
+      response = conn |> json_response(200)
+      assert response["total_pages"] == 1
+      assert length(response["panels"]) == response["total_entries"]
+    end
+
+    test "Pagination", %{conn: conn} do
+      panel = insert(:panel)
+
+      params = %{
+        "page_size" => 2,
+        "page_number" => 1
+      }
+
+      conn =
+        get(
+          conn,
+          Routes.panel_path(conn, :index, panel.org_id, panel.dashboard_id, params)
+        )
+
+      page1_response = conn |> json_response(200)
+      assert page1_response["page_number"] == params["page_number"]
+      assert page1_response["page_size"] == params["page_size"]
+      assert page1_response["total_pages"] == 1
+    end
+
+    test "fails if invalid token in authorization header", %{conn: conn} do
+      bad_access_token = "qwerty1234567qwerty12"
+      panel = insert(:panel)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{bad_access_token}")
+
+      params = %{
+        "page_size" => 2,
+        "page_number" => 1
+      }
+
+      conn =
+        get(
+          conn,
+          Routes.panel_path(conn, :index, panel.org_id, panel.dashboard_id, params)
+        )
+
+      result = conn |> json_response(403)
+      assert result == %{"errors" => %{"message" => "Unauthorized"}}
+    end
+  end
+end

--- a/apps/acqdat_api/test/acqdat_api_web/controllers/dashboard-management/widget_instance_controller_test.exs
+++ b/apps/acqdat_api/test/acqdat_api_web/controllers/dashboard-management/widget_instance_controller_test.exs
@@ -32,7 +32,7 @@ defmodule AcqdatApiWeb.DashboardManagement.WidgetInstanceControllerTest do
             conn,
             :show,
             org.id,
-            widget_instance.dashboard_id,
+            widget_instance.panel_id,
             widget_instance.widget_id,
             3
           )
@@ -58,7 +58,7 @@ defmodule AcqdatApiWeb.DashboardManagement.WidgetInstanceControllerTest do
             conn,
             :show,
             org.id,
-            widget_instance.dashboard_id,
+            widget_instance.panel_id,
             widget_instance.widget_id,
             params.id
           )
@@ -80,7 +80,7 @@ defmodule AcqdatApiWeb.DashboardManagement.WidgetInstanceControllerTest do
             conn,
             :show,
             org.id,
-            widget_instance.dashboard_id,
+            widget_instance.panel_id,
             widget_instance.widget_id,
             widget_instance.id
           )
@@ -100,16 +100,16 @@ defmodule AcqdatApiWeb.DashboardManagement.WidgetInstanceControllerTest do
 
     setup do
       org = insert(:organisation)
-      dashboard = insert(:dashboard)
+      panel = insert(:panel)
       widget = insert(:widget)
 
-      [org: org, dashboard: dashboard, widget: widget]
+      [org: org, panel: panel, widget: widget]
     end
 
     test "widget_instance create successfully", %{
       conn: conn,
       org: org,
-      dashboard: dashboard,
+      panel: panel,
       widget: widget
     } do
       widget_instance_manifest = build(:widget_instance)
@@ -121,7 +121,7 @@ defmodule AcqdatApiWeb.DashboardManagement.WidgetInstanceControllerTest do
       conn =
         post(
           conn,
-          Routes.create_widget_instances_path(conn, :create, org.id, dashboard.id, widget.id),
+          Routes.create_widget_instances_path(conn, :create, org.id, panel.id, widget.id),
           data
         )
 
@@ -146,7 +146,7 @@ defmodule AcqdatApiWeb.DashboardManagement.WidgetInstanceControllerTest do
     test "fails if required params are missing", %{
       conn: conn,
       org: org,
-      dashboard: dashboard,
+      panel: panel,
       widget: widget
     } do
       data = %{}
@@ -154,7 +154,7 @@ defmodule AcqdatApiWeb.DashboardManagement.WidgetInstanceControllerTest do
       conn =
         post(
           conn,
-          Routes.create_widget_instances_path(conn, :create, org.id, dashboard.id, widget.id),
+          Routes.create_widget_instances_path(conn, :create, org.id, panel.id, widget.id),
           data
         )
 

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/command_widget.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/command_widget.ex
@@ -41,11 +41,11 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidget do
     end
   end
 
-  def get_all_by_dashboard_id(dashboard_id) do
+  def get_all_by_panel_id(panel_id) do
     query =
       from(
         widget in CommandWidget,
-        where: widget.dashboard_id == ^dashboard_id
+        where: widget.panel_id == ^panel_id
       )
 
     Repo.all(query)

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/dashboard.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/dashboard.ex
@@ -29,20 +29,12 @@ defmodule AcqdatCore.Model.DashboardManagement.Dashboard do
     end
   end
 
-  def get_with_widgets(id) when is_integer(id) do
-    case Repo.get(Dashboard, id) do
+  def get_with_panels(id) when is_integer(id) do
+    case Repo.get(Dashboard, id) |> Repo.preload([:panels]) do
       nil ->
         {:error, "dashboard with this id not found"}
 
       dashboard ->
-        widgets = WidgetInstanceModel.get_all_by_dashboard_id(dashboard.id)
-        command_widgets = CommandWidget.get_all_by_dashboard_id(dashboard.id)
-
-        dashboard =
-          dashboard
-          |> Map.put(:widgets, widgets)
-          |> Map.put(:command_widgets, command_widgets)
-
         {:ok, dashboard}
     end
   end

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/panel.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/panel.ex
@@ -1,13 +1,28 @@
 defmodule AcqdatCore.Model.DashboardManagement.Panel do
   import Ecto.Query
   alias AcqdatCore.DashboardManagement.Schema.Panel
-  # alias AcqdatCore.Model.DashboardManagement.WidgetInstance, as: WidgetInstanceModel
-  # alias AcqdatCore.Model.DashboardManagement.CommandWidget
+  alias AcqdatCore.Model.DashboardManagement.WidgetInstance, as: WidgetInstanceModel
+  alias AcqdatCore.Model.DashboardManagement.CommandWidget
   alias AcqdatCore.Repo
 
   def create(params) do
     changeset = Panel.changeset(%Panel{}, params)
     Repo.insert(changeset)
+  end
+
+  def update(panel, params) do
+    changeset = Panel.update_changeset(panel, params)
+    Repo.update(changeset)
+  end
+
+  def get_by_id(id) when is_integer(id) do
+    case Repo.get(Panel, id) do
+      nil ->
+        {:error, "panel with this id not found"}
+
+      panel ->
+        {:ok, panel}
+    end
   end
 
   def get_all(%{
@@ -23,5 +38,28 @@ defmodule AcqdatCore.Model.DashboardManagement.Panel do
       )
 
     query |> Repo.paginate(page: page_number, page_size: page_size)
+  end
+
+  def get_with_widgets(id) when is_integer(id) do
+    case Repo.get(Panel, id) do
+      nil ->
+        {:error, "panel with this id not found"}
+
+      panel ->
+        widgets = WidgetInstanceModel.get_all_by_panel_id(panel.id)
+        command_widgets = CommandWidget.get_all_by_panel_id(panel.id)
+
+        panel =
+          panel
+          |> Map.put(:widgets, widgets)
+          |> Map.put(:command_widgets, command_widgets)
+
+        {:ok, panel}
+    end
+  end
+
+  def delete_all(ids) when is_list(ids) do
+    from(panel in Panel, where: panel.id in ^ids)
+    |> Repo.delete_all()
   end
 end

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/panel.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/panel.ex
@@ -1,0 +1,27 @@
+defmodule AcqdatCore.Model.DashboardManagement.Panel do
+  import Ecto.Query
+  alias AcqdatCore.DashboardManagement.Schema.Panel
+  # alias AcqdatCore.Model.DashboardManagement.WidgetInstance, as: WidgetInstanceModel
+  # alias AcqdatCore.Model.DashboardManagement.CommandWidget
+  alias AcqdatCore.Repo
+
+  def create(params) do
+    changeset = Panel.changeset(%Panel{}, params)
+    Repo.insert(changeset)
+  end
+
+  def get_all(%{
+        page_size: page_size,
+        page_number: page_number,
+        org_id: org_id,
+        dashboard_id: dashboard_id
+      }) do
+    query =
+      from(panel in Panel,
+        where: panel.org_id == ^org_id and panel.dashboard_id == ^dashboard_id,
+        order_by: panel.name
+      )
+
+    query |> Repo.paginate(page: page_number, page_size: page_size)
+  end
+end

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/widget_instance.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/widget_instance.ex
@@ -24,11 +24,11 @@ defmodule AcqdatCore.Model.DashboardManagement.WidgetInstance do
     end
   end
 
-  def get_all_by_dashboard_id(dashboard_id) do
+  def get_all_by_panel_id(panel_id) do
     widget_instances =
       from(widget_instance in WidgetInstance,
         preload: [:widget],
-        where: widget_instance.dashboard_id == ^dashboard_id
+        where: widget_instance.panel_id == ^panel_id
       )
       |> Repo.all()
 

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/command_widget/command_widget.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/command_widget/command_widget.ex
@@ -45,6 +45,7 @@ defmodule AcqdatCore.DashboardManagement.Schema.CommandWidget do
     |> validate_required(@required)
     |> add_command_widget_type()
     |> assoc_constraint(:gateway)
+    |> assoc_constraint(:panel)
   end
 
   defp add_uuid(%Ecto.Changeset{valid?: true} = changeset) do

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/command_widget/command_widget.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/command_widget/command_widget.ex
@@ -5,7 +5,7 @@ defmodule AcqdatCore.DashboardManagement.Schema.CommandWidget do
 
   use AcqdatCore.Schema
   alias AcqdatCore.Schema.IotManager.Gateway
-  alias AcqdatCore.DashboardManagement.Schema.Dashboard
+  alias AcqdatCore.DashboardManagement.Schema.Panel
 
   @callback handle_command(data_setting_parameters :: map) ::
               {:ok, String.t()} | {:error, String.t()}
@@ -28,12 +28,12 @@ defmodule AcqdatCore.DashboardManagement.Schema.CommandWidget do
 
     # associations
     belongs_to(:gateway, Gateway, on_replace: :delete)
-    belongs_to(:dashboard, Dashboard, on_replace: :delete)
+    belongs_to(:panel, Panel, on_replace: :delete)
 
     timestamps(type: :utc_datetime)
   end
 
-  @required ~w(label module gateway_id dashboard_id)a
+  @required ~w(label module gateway_id panel_id)a
   @optional ~w(properties uuid data_settings
     visual_settings command_widget_type)a
   @permitted @required ++ @optional
@@ -45,7 +45,6 @@ defmodule AcqdatCore.DashboardManagement.Schema.CommandWidget do
     |> validate_required(@required)
     |> add_command_widget_type()
     |> assoc_constraint(:gateway)
-    |> assoc_constraint(:dashboard)
   end
 
   defp add_uuid(%Ecto.Changeset{valid?: true} = changeset) do

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/dashboard.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/dashboard.ex
@@ -10,7 +10,7 @@ defmodule AcqdatCore.DashboardManagement.Schema.Dashboard do
   """
   use AcqdatCore.Schema
   alias AcqdatCore.Schema.EntityManagement.Organisation
-  alias AcqdatCore.DashboardManagement.Schema.{WidgetInstance, CommandWidget}
+  alias AcqdatCore.DashboardManagement.Schema.{Panel, WidgetInstance, CommandWidget}
 
   @typedoc """
   `name`: Name of the dashboard, which will be unique with respective to org.
@@ -28,6 +28,7 @@ defmodule AcqdatCore.DashboardManagement.Schema.Dashboard do
 
     # associations
     belongs_to(:org, Organisation, on_replace: :delete)
+    has_many(:panels, Panel, on_replace: :delete)
     has_many(:widget_instances, WidgetInstance, on_replace: :delete)
     has_many(:command_widgets, CommandWidget)
 

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/dashboard.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/dashboard.ex
@@ -24,7 +24,7 @@ defmodule AcqdatCore.DashboardManagement.Schema.Dashboard do
     field(:uuid, :string, null: false)
     field(:slug, :string, null: false)
     field(:settings, :map)
-    field(:widget_layouts, :map)
+    field(:avatar, :string)
 
     # associations
     belongs_to(:org, Organisation, on_replace: :delete)
@@ -36,7 +36,7 @@ defmodule AcqdatCore.DashboardManagement.Schema.Dashboard do
   end
 
   @required_params ~w(uuid slug name org_id)a
-  @optional_params ~w(settings description widget_layouts)a
+  @optional_params ~w(settings description avatar)a
   @permitted @optional_params ++ @required_params
 
   def changeset(%__MODULE__{} = dashboard, params) do

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/dashboard.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/dashboard.ex
@@ -10,7 +10,8 @@ defmodule AcqdatCore.DashboardManagement.Schema.Dashboard do
   """
   use AcqdatCore.Schema
   alias AcqdatCore.Schema.EntityManagement.Organisation
-  alias AcqdatCore.DashboardManagement.Schema.{Panel, WidgetInstance, CommandWidget}
+  alias AcqdatCore.DashboardManagement.Schema.Panel
+  alias AcqdatCore.DashboardManagement.Schema.Dashboard.Settings
 
   @typedoc """
   `name`: Name of the dashboard, which will be unique with respective to org.
@@ -23,20 +24,20 @@ defmodule AcqdatCore.DashboardManagement.Schema.Dashboard do
     field(:description, :string)
     field(:uuid, :string, null: false)
     field(:slug, :string, null: false)
-    field(:settings, :map)
     field(:avatar, :string)
 
     # associations
     belongs_to(:org, Organisation, on_replace: :delete)
     has_many(:panels, Panel, on_replace: :delete)
-    has_many(:widget_instances, WidgetInstance, on_replace: :delete)
-    has_many(:command_widgets, CommandWidget)
+
+    # embedded associations
+    embeds_one(:settings, Settings, on_replace: :delete)
 
     timestamps(type: :utc_datetime)
   end
 
   @required_params ~w(uuid slug name org_id)a
-  @optional_params ~w(settings description avatar)a
+  @optional_params ~w(description avatar)a
   @permitted @optional_params ++ @required_params
 
   def changeset(%__MODULE__{} = dashboard, params) do
@@ -58,6 +59,7 @@ defmodule AcqdatCore.DashboardManagement.Schema.Dashboard do
   @spec common_changeset(Ecto.Changeset.t()) :: Ecto.Changeset.t()
   def common_changeset(changeset) do
     changeset
+    |> cast_embed(:settings, with: &Settings.changeset/2)
     |> assoc_constraint(:org)
     |> unique_constraint(:name,
       name: :unique_dashboard_name_per_org,
@@ -78,5 +80,26 @@ defmodule AcqdatCore.DashboardManagement.Schema.Dashboard do
 
   defp random_string(length) do
     :crypto.strong_rand_bytes(length) |> Base.url_encode64() |> binary_part(0, length)
+  end
+end
+
+defmodule AcqdatCore.DashboardManagement.Schema.Dashboard.Settings do
+  @moduledoc """
+  Embed schema for settings related to dashboard.
+  """
+
+  use AcqdatCore.Schema
+
+  embedded_schema do
+    field(:background_color, :string, default: "#FFFFFF")
+    field(:sidebar_color, :string, default: "#000000")
+    field(:client_name, :string)
+  end
+
+  @permitted ~w(background_color sidebar_color client_name)a
+
+  def changeset(%__MODULE__{} = settings, params) do
+    settings
+    |> cast(params, @permitted)
   end
 end

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/panel.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/panel.ex
@@ -39,8 +39,8 @@ defmodule AcqdatCore.DashboardManagement.Schema.Panel do
   @optional_params ~w(settings description widget_layouts)a
   @permitted @optional_params ++ @required_params
 
-  def changeset(%__MODULE__{} = dashboard, params) do
-    dashboard
+  def changeset(%__MODULE__{} = panel, params) do
+    panel
     |> cast(params, @permitted)
     |> add_slug()
     |> add_uuid()
@@ -48,8 +48,8 @@ defmodule AcqdatCore.DashboardManagement.Schema.Panel do
     |> common_changeset()
   end
 
-  def update_changeset(%__MODULE__{} = dashboard, params) do
-    dashboard
+  def update_changeset(%__MODULE__{} = panel, params) do
+    panel
     |> cast(params, @permitted)
     |> validate_required(@required_params)
     |> common_changeset()

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/panel.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/panel.ex
@@ -1,21 +1,21 @@
 defmodule AcqdatCore.DashboardManagement.Schema.Panel do
   @moduledoc """
-  Models a Dashboard Entity.
+  Models a Dashboard's Panel Entity.
 
-  Dashboard are used for visually representing collection of widgets to user.
+  Panels are used for grouping collection of widgets and providing them with a identifier.
 
-  Any particular org can have multiple dashboards.
+  Any particular odashboard can have multiple panels.
 
-  A dashboard consists of multiple widgets.
+  A Panel consists of multiple widgets.
   """
   use AcqdatCore.Schema
   alias AcqdatCore.Schema.EntityManagement.Organisation
   alias AcqdatCore.DashboardManagement.Schema.{Dashboard, WidgetInstance, CommandWidget}
 
   @typedoc """
-  `name`: Name of the dashboard, which will be unique with respective to org.
-  `uuid`: A universally unique id to identify the Dashboard.
-  `settings`: All the settings of dashboard
+  `name`: Name of the panel, which will be unique with respective to dashboard.
+  `uuid`: A universally unique id to identify the panel.
+  `settings`: All the settings of panel
   """
   @type t :: %__MODULE__{}
   schema("acqdat_panel") do

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/panel.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/panel.ex
@@ -1,0 +1,83 @@
+defmodule AcqdatCore.DashboardManagement.Schema.Panel do
+  @moduledoc """
+  Models a Dashboard Entity.
+
+  Dashboard are used for visually representing collection of widgets to user.
+
+  Any particular org can have multiple dashboards.
+
+  A dashboard consists of multiple widgets.
+  """
+  use AcqdatCore.Schema
+  alias AcqdatCore.Schema.EntityManagement.Organisation
+  alias AcqdatCore.DashboardManagement.Schema.{Dashboard, WidgetInstance, CommandWidget}
+
+  @typedoc """
+  `name`: Name of the dashboard, which will be unique with respective to org.
+  `uuid`: A universally unique id to identify the Dashboard.
+  `settings`: All the settings of dashboard
+  """
+  @type t :: %__MODULE__{}
+  schema("acqdat_panel") do
+    field(:name, :string, null: false)
+    field(:description, :string)
+    field(:uuid, :string, null: false)
+    field(:slug, :string, null: false)
+    field(:settings, :map)
+    field(:widget_layouts, :map)
+
+    # associations
+    belongs_to(:org, Organisation, on_replace: :delete)
+    belongs_to(:dashboard, Dashboard, on_replace: :delete)
+    has_many(:widget_instances, WidgetInstance, on_replace: :delete)
+    has_many(:command_widgets, CommandWidget)
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @required_params ~w(uuid slug name org_id dashboard_id)a
+  @optional_params ~w(settings description widget_layouts)a
+  @permitted @optional_params ++ @required_params
+
+  def changeset(%__MODULE__{} = dashboard, params) do
+    dashboard
+    |> cast(params, @permitted)
+    |> add_slug()
+    |> add_uuid()
+    |> validate_required(@required_params)
+    |> common_changeset()
+  end
+
+  def update_changeset(%__MODULE__{} = dashboard, params) do
+    dashboard
+    |> cast(params, @permitted)
+    |> validate_required(@required_params)
+    |> common_changeset()
+  end
+
+  @spec common_changeset(Ecto.Changeset.t()) :: Ecto.Changeset.t()
+  def common_changeset(changeset) do
+    changeset
+    |> assoc_constraint(:org)
+    |> assoc_constraint(:dashboard)
+    |> unique_constraint(:name,
+      name: :unique_panel_name_per_dashboard,
+      message: "unique panel name under dashboard"
+    )
+  end
+
+  # TODO: Need to remove these codes, after fbp branch is merged to master
+  defp add_uuid(%Ecto.Changeset{valid?: true} = changeset) do
+    changeset
+    |> put_change(:uuid, UUID.uuid1(:hex))
+  end
+
+  defp add_slug(%Ecto.Changeset{valid?: true} = changeset) do
+    changeset
+    |> put_change(:slug, Slugger.slugify(random_string(12)))
+  end
+
+  defp random_string(length) do
+    :crypto.strong_rand_bytes(length) |> Base.url_encode64() |> binary_part(0, length)
+  end
+end

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/widget_instance.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/widget_instance.ex
@@ -3,7 +3,7 @@ defmodule AcqdatCore.DashboardManagement.Schema.WidgetInstance do
   WidgetInstance are instances of the class Widget, holding the same behaviour as that of widgets,
   but with different data-sources.
 
-  It is used to model associations between dashboard and widget
+  It is used to model associations between dashboard's panel and widget
 
   A widget_instance has four important properties along with others:
   - `visual_properties`
@@ -29,7 +29,7 @@ defmodule AcqdatCore.DashboardManagement.Schema.WidgetInstance do
 
   use AcqdatCore.Schema
   alias AcqdatCore.Widgets.Schema.Widget
-  alias AcqdatCore.DashboardManagement.Schema.{Panel, Dashboard}
+  alias AcqdatCore.DashboardManagement.Schema.Panel
   alias AcqdatCore.DashboardManagement.Schema.WidgetInstance.SeriesData
 
   @typedoc """
@@ -53,13 +53,12 @@ defmodule AcqdatCore.DashboardManagement.Schema.WidgetInstance do
 
     # associations
     belongs_to(:widget, Widget, on_replace: :delete)
-    belongs_to(:dashboard, Dashboard, on_replace: :delete)
     belongs_to(:panel, Panel, on_replace: :delete)
 
     timestamps(type: :utc_datetime)
   end
 
-  @required ~w(label widget_id dashboard_id panel_id slug uuid)a
+  @required ~w(label widget_id panel_id slug uuid)a
   @optional ~w(widget_settings visual_properties)a
   @permitted @required ++ @optional
 
@@ -89,7 +88,6 @@ defmodule AcqdatCore.DashboardManagement.Schema.WidgetInstance do
   defp common_changeset(changeset) do
     changeset
     |> assoc_constraint(:widget)
-    |> assoc_constraint(:dashboard)
     |> assoc_constraint(:panel)
     |> unique_constraint(:label,
       name: :unique_widget_name_per_panel,

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/widget_instance.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/widget_instance.ex
@@ -29,7 +29,7 @@ defmodule AcqdatCore.DashboardManagement.Schema.WidgetInstance do
 
   use AcqdatCore.Schema
   alias AcqdatCore.Widgets.Schema.Widget
-  alias AcqdatCore.DashboardManagement.Schema.Dashboard
+  alias AcqdatCore.DashboardManagement.Schema.{Panel, Dashboard}
   alias AcqdatCore.DashboardManagement.Schema.WidgetInstance.SeriesData
 
   @typedoc """
@@ -54,11 +54,12 @@ defmodule AcqdatCore.DashboardManagement.Schema.WidgetInstance do
     # associations
     belongs_to(:widget, Widget, on_replace: :delete)
     belongs_to(:dashboard, Dashboard, on_replace: :delete)
+    belongs_to(:panel, Panel, on_replace: :delete)
 
     timestamps(type: :utc_datetime)
   end
 
-  @required ~w(label widget_id dashboard_id slug uuid)a
+  @required ~w(label widget_id dashboard_id panel_id slug uuid)a
   @optional ~w(widget_settings visual_properties)a
   @permitted @required ++ @optional
 
@@ -89,9 +90,10 @@ defmodule AcqdatCore.DashboardManagement.Schema.WidgetInstance do
     changeset
     |> assoc_constraint(:widget)
     |> assoc_constraint(:dashboard)
+    |> assoc_constraint(:panel)
     |> unique_constraint(:label,
-      name: :unique_widget_name_per_dashboard,
-      message: "unique widget label under dashboard"
+      name: :unique_widget_name_per_panel,
+      message: "unique widget label under dashboard's panel"
     )
   end
 

--- a/apps/acqdat_core/lib/acqdat_core/widgets/schema/vendor_enum.ex
+++ b/apps/acqdat_core/lib/acqdat_core/widgets/schema/vendor_enum.ex
@@ -4,11 +4,13 @@ import EctoEnum
 # contains the name of the module which will define the module
 # contianing all the key definitions for a vendor.
 defenum(WidgetVendorSchemaEnum,
-  "Elixir.AcqdatCore.Widgets.Schema.Vendors.HighCharts": 0
+  "Elixir.AcqdatCore.Widgets.Schema.Vendors.HighCharts": 0,
+  "Elixir.AcqdatCore.Widgets.Schema.Vendors.CustomCards": 1
 )
 
 # Creates an enum for different vendors for which widget
 # type is created.
 defenum(WidgetVendorEnum,
-  Highcharts: 0
+  HighCharts: 0,
+  CustomCards: 1
 )

--- a/apps/acqdat_core/lib/acqdat_core/widgets/schema/vendors/custom_cards.ex
+++ b/apps/acqdat_core/lib/acqdat_core/widgets/schema/vendors/custom_cards.ex
@@ -1,0 +1,59 @@
+defmodule AcqdatCore.Widgets.Schema.Vendors.CustomCards do
+  alias AcqdatCore.Model.EntityManagement.SensorData
+
+  @moduledoc """
+    Embedded Schema of the settings of the widget with it keys and subkeys
+  """
+  @data_types ~w(string color object list integer boolean)a
+
+  defstruct card: %{
+              data_type: :object,
+              user_controlled: false,
+              properties: %{
+                type: %{data_type: :string, default_value: "", user_controlled: false},
+                backgroundColor: %{
+                  data_type: :color,
+                  default_value: "#ffffff",
+                  user_controlled: true
+                },
+                font: %{data_type: :string, default_value: "#ffffff", user_controlled: true}
+              }
+            },
+            title: %{
+              data_type: :object,
+              user_controlled: false,
+              properties: %{
+                text: %{data_type: :string, default_value: "", user_controlled: true},
+                align: %{data_type: :string, default_value: "center", user_controlled: true}
+              }
+            },
+            unit: %{
+              data_type: :object,
+              user_controlled: false,
+              properties: %{
+                text: %{data_type: :string, default_value: "", user_controlled: true},
+                align: %{data_type: :string, default_value: "center", user_controlled: true}
+              }
+            },
+            icon: %{
+              data_type: :object,
+              user_controlled: false,
+              properties: %{
+                text: %{data_type: :string, default_value: "", user_controlled: true},
+                align: %{data_type: :string, default_value: "center", user_controlled: true}
+              }
+            },
+            description: %{
+              data_type: :object,
+              user_controlled: false,
+              properties: %{
+                text: %{data_type: :string, default_value: "", user_controlled: true},
+                align: %{data_type: :string, default_value: "center", user_controlled: true}
+              }
+            },
+            series: %{
+              data_type: :list,
+              user_defined: false,
+              properties: %{}
+            }
+end

--- a/apps/acqdat_core/priv/repo/migrations/20200824173338_create_panels_table.exs
+++ b/apps/acqdat_core/priv/repo/migrations/20200824173338_create_panels_table.exs
@@ -1,0 +1,22 @@
+defmodule AcqdatCore.Repo.Migrations.CreatePanelsTable do
+  use Ecto.Migration
+
+  def change do
+  	create table("acqdat_panel") do
+      add(:name, :string, null: false)
+      add(:description, :string)
+      add(:uuid, :string, null: false)
+      add(:slug, :string, null: false)
+      add(:settings, :map)
+      add(:widget_layouts, :map)
+      add(:org_id, references("acqdat_organisation", on_delete: :delete_all), null: false)
+      add(:dashboard_id, references("acqdat_dashboard", on_delete: :delete_all), null: false)
+
+      timestamps(type: :timestamptz)
+    end
+
+    create unique_index("acqdat_panel", [:slug])
+    create unique_index("acqdat_panel", [:uuid])
+    create unique_index("acqdat_panel", [:dashboard_id, :name], name: :unique_panel_name_per_dashboard)
+  end
+end

--- a/apps/acqdat_core/priv/repo/migrations/20200825070010_alter_widget_instance.exs
+++ b/apps/acqdat_core/priv/repo/migrations/20200825070010_alter_widget_instance.exs
@@ -8,7 +8,7 @@ defmodule AcqdatCore.Repo.Migrations.AlterWidgetInstance do
     end
     
     drop_if_exists index("acqdat_widget_instance", [:name], name: :unique_widget_name_per_dashboard)
-    create unique_index("acqdat_widget_instance", [:panel_id, :label], where: "panel_id != null", name: :unique_widget_name_per_panel)
+    create unique_index("acqdat_widget_instance", [:panel_id, :label], name: :unique_widget_name_per_panel)
   end
 
   def down do

--- a/apps/acqdat_core/priv/repo/migrations/20200825070010_alter_widget_instance.exs
+++ b/apps/acqdat_core/priv/repo/migrations/20200825070010_alter_widget_instance.exs
@@ -4,6 +4,7 @@ defmodule AcqdatCore.Repo.Migrations.AlterWidgetInstance do
   def up do
     alter table("acqdat_widget_instance") do
       add(:panel_id, references("acqdat_panel", on_delete: :delete_all))
+      remove(:dashboard_id)
     end
     
     drop_if_exists index("acqdat_widget_instance", [:name], name: :unique_widget_name_per_dashboard)
@@ -12,10 +13,10 @@ defmodule AcqdatCore.Repo.Migrations.AlterWidgetInstance do
 
   def down do
     drop_if_exists index("acqdat_widget_instance", [:name], name: :unique_widget_name_per_panel)
-    create unique_index("acqdat_widget_instance", [:dashboard_id, :label], name: :unique_widget_name_per_dashboard)
-    
     alter table("acqdat_widget_instance") do
       remove(:panel_id)
+      add(:dashboard_id, references("acqdat_dashboard", on_delete: :delete_all))
     end
+    create unique_index("acqdat_widget_instance", [:dashboard_id, :label], name: :unique_widget_name_per_dashboard)
   end
 end

--- a/apps/acqdat_core/priv/repo/migrations/20200825070010_alter_widget_instance.exs
+++ b/apps/acqdat_core/priv/repo/migrations/20200825070010_alter_widget_instance.exs
@@ -1,0 +1,21 @@
+defmodule AcqdatCore.Repo.Migrations.AlterWidgetInstance do
+  use Ecto.Migration
+
+  def up do
+    alter table("acqdat_widget_instance") do
+      add(:panel_id, references("acqdat_panel", on_delete: :delete_all))
+    end
+    
+    drop_if_exists index("acqdat_widget_instance", [:name], name: :unique_widget_name_per_dashboard)
+    create unique_index("acqdat_widget_instance", [:panel_id, :label], where: "panel_id != null", name: :unique_widget_name_per_panel)
+  end
+
+  def down do
+    drop_if_exists index("acqdat_widget_instance", [:name], name: :unique_widget_name_per_panel)
+    create unique_index("acqdat_widget_instance", [:dashboard_id, :label], name: :unique_widget_name_per_dashboard)
+    
+    alter table("acqdat_widget_instance") do
+      remove(:panel_id)
+    end
+  end
+end

--- a/apps/acqdat_core/priv/repo/migrations/20200825112548_alter_command_widget_to_include_panel.exs
+++ b/apps/acqdat_core/priv/repo/migrations/20200825112548_alter_command_widget_to_include_panel.exs
@@ -1,0 +1,17 @@
+defmodule AcqdatCore.Repo.Migrations.AlterCommandWidgetToIncludePanel do
+  use Ecto.Migration
+
+  def up do
+    alter table("acqdat_command_widgets") do
+      add(:panel_id, references("acqdat_panel", on_delete: :delete_all))
+      remove(:dashboard_id)
+    end
+  end
+
+  def down do
+    alter table("acqdat_command_widgets") do
+      remove(:panel_id)
+      add(:dashboard_id, references("acqdat_dashboard", on_delete: :delete_all))
+    end
+  end
+end

--- a/apps/acqdat_core/priv/repo/migrations/20200826101828_add_logo_and_remove_layouts_from_dashboard_table.exs
+++ b/apps/acqdat_core/priv/repo/migrations/20200826101828_add_logo_and_remove_layouts_from_dashboard_table.exs
@@ -1,0 +1,17 @@
+defmodule AcqdatCore.Repo.Migrations.AddLogoAndRemoveLayoutsFromDashboardTable do
+  use Ecto.Migration
+
+  def up do
+    alter table("acqdat_dashboard") do
+      remove(:widget_layouts)
+      add(:avatar, :string)
+    end
+  end
+
+  def down do
+    alter table("acqdat_dashboard") do
+      remove(:avatar)
+      add(:widget_layouts, :map)
+    end
+  end
+end

--- a/apps/acqdat_core/priv/repo/seed/widget.ex
+++ b/apps/acqdat_core/priv/repo/seed/widget.ex
@@ -2,7 +2,7 @@ defmodule AcqdatCore.Seed.Widget do
   @moduledoc """
   Holds seeds for initial widgets.
   """
-  alias AcqdatCore.Seed.Widgets.{Line, Area, Pie, Bar, LineTimeseries, AreaTimeseries, GaugeSeries, SolidGauge, StockSingleLine}
+  alias AcqdatCore.Seed.Widgets.{Line, Area, Pie, Bar, LineTimeseries, AreaTimeseries, GaugeSeries, SolidGauge, StockSingleLine, DynamicCard, ImageCard, StaticCard}
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
 
   def seed() do
@@ -16,6 +16,9 @@ defmodule AcqdatCore.Seed.Widget do
     GaugeSeries.seed()
     SolidGauge.seed()
     StockSingleLine.seed()
+    DynamicCard.seed()
+    ImageCard.seed()
+    StaticCard.seed()
     WidgetHelpers.seed_in_elastic()
   end
 end

--- a/apps/acqdat_core/priv/repo/seed/widgets/area.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/area.ex
@@ -5,6 +5,7 @@ defmodule AcqdatCore.Seed.Widgets.Area do
   alias AcqdatCore.Repo
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
+  alias AcqdatCore.Widgets.Schema.Vendors.HighCharts
 
   @highchart_key_widget_settings %{
     area: %{
@@ -88,7 +89,7 @@ defmodule AcqdatCore.Seed.Widgets.Area do
   }
 
   def seed() do
-    widget_type = WidgetHelpers.return_widget_type()
+    widget_type = WidgetHelpers.find_or_create_widget_type("HighCharts")
     seed_widgets(widget_type)
   end
 
@@ -113,8 +114,8 @@ defmodule AcqdatCore.Seed.Widgets.Area do
       category: ["chart", "area"],
       policies: %{},
       widget_type_id: widget_type.id,
-      visual_settings: WidgetHelpers.do_settings(widget_settings, :visual),
-      data_settings: WidgetHelpers.do_settings(widget_settings, :data),
+      visual_settings: WidgetHelpers.do_settings(widget_settings, :visual, %HighCharts{}),
+      data_settings: WidgetHelpers.do_settings(widget_settings, :data, %HighCharts{}),
       default_values: data
     }
   end

--- a/apps/acqdat_core/priv/repo/seed/widgets/area_timeseries.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/area_timeseries.ex
@@ -5,6 +5,7 @@ defmodule AcqdatCore.Seed.Widgets.AreaTimeseries do
   alias AcqdatCore.Repo
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
+  alias AcqdatCore.Widgets.Schema.Vendors.HighCharts
 
   @highchart_key_widget_settings %{
     area: %{
@@ -89,7 +90,7 @@ defmodule AcqdatCore.Seed.Widgets.AreaTimeseries do
   }
 
   def seed() do
-    widget_type = WidgetHelpers.return_widget_type()
+    widget_type = WidgetHelpers.find_or_create_widget_type("HighCharts")
     seed_widgets(widget_type)
   end
 
@@ -114,8 +115,8 @@ defmodule AcqdatCore.Seed.Widgets.AreaTimeseries do
       category: ["chart", "area"],
       policies: %{},
       widget_type_id: widget_type.id,
-      visual_settings: WidgetHelpers.do_settings(widget_settings, :visual),
-      data_settings: WidgetHelpers.do_settings(widget_settings, :data),
+      visual_settings: WidgetHelpers.do_settings(widget_settings, :visual, %HighCharts{}),
+      data_settings: WidgetHelpers.do_settings(widget_settings, :data, %HighCharts{}),
       default_values: data
     }
   end

--- a/apps/acqdat_core/priv/repo/seed/widgets/bar.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/bar.ex
@@ -5,6 +5,7 @@ defmodule AcqdatCore.Seed.Widgets.Bar do
   alias AcqdatCore.Repo
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
+  alias AcqdatCore.Widgets.Schema.Vendors.HighCharts
 
   @highchart_key_widget_settings %{
     bar: %{
@@ -78,7 +79,7 @@ defmodule AcqdatCore.Seed.Widgets.Bar do
   }
 
   def seed() do
-    widget_type = WidgetHelpers.return_widget_type()
+    widget_type = WidgetHelpers.find_or_create_widget_type("HighCharts")
     seed_widgets(widget_type)
   end
 
@@ -103,8 +104,8 @@ defmodule AcqdatCore.Seed.Widgets.Bar do
       category: ["chart", "bar"],
       policies: %{},
       widget_type_id: widget_type.id,
-      visual_settings: WidgetHelpers.do_settings(widget_settings, :visual),
-      data_settings: WidgetHelpers.do_settings(widget_settings, :data),
+      visual_settings: WidgetHelpers.do_settings(widget_settings, :visual, %HighCharts{}),
+      data_settings: WidgetHelpers.do_settings(widget_settings, :data, %HighCharts{}),
       default_values: data
     }
   end

--- a/apps/acqdat_core/priv/repo/seed/widgets/dynamic_card.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/dynamic_card.ex
@@ -1,0 +1,86 @@
+defmodule AcqdatCore.Seed.Widgets.DynamicCard do
+  @moduledoc """
+  Holds seeds for DynamicCard widgets.
+  """
+  alias AcqdatCore.Repo
+  alias AcqdatCore.Seed.Helpers.WidgetHelpers
+  alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
+  alias AcqdatCore.Widgets.Schema.Vendors.CustomCards
+
+  @custom_card_key_widget_settings %{
+    card: %{
+      visual: %{
+        card: [type: %{value: "dynamic card"}, backgroundColor: %{}, font: %{}],
+        title: [text: %{}, align: %{}],
+        unit: [text: %{}, align: %{}],
+        icon: [text: %{}, align: %{}],
+        description: [text: %{}, align: %{}]
+      },
+      data: %{
+        series: %{
+          data_type: :object,
+          value: %{},
+          properties: %{
+            multiple: %{data_type: :boolean, value: %{data: false}, properties: %{}}
+          }
+        },
+        axes: %{
+          data_type: :object,
+          value: %{},
+          properties: %{
+            multiple: %{data_type: :boolean, value: %{data: false}, properties: %{}},
+            y: %{data_type: :list, value: %{}, properties: %{}}
+          }
+        }
+      }
+    }
+  }
+
+  @custom_card_value_settings %{
+    card: %{
+      visual_setting_values: %{
+        title: %{text: "temp"},
+        unit: %{text: "Celsius"}
+      },
+      data_settings_values: %{
+        series: [
+          %{
+            data: [%{y: 2}]
+          }
+        ]
+     }
+    }
+  }
+
+  def seed() do
+    widget_type = WidgetHelpers.find_or_create_widget_type("CustomCards")
+    seed_widgets(widget_type)
+  end
+
+  def seed_widgets(widget_type) do
+    @custom_card_key_widget_settings
+    |> Enum.map(fn {key, widget_settings} ->
+      set_widget_data(key, widget_settings, @custom_card_value_settings[key],
+        widget_type)
+    end)
+    |> Enum.each(fn data ->
+      Repo.insert!(data)
+    end)
+  end
+
+  def set_widget_data(_key, widget_settings, data, widget_type) do
+    %WidgetSchema{
+      label: "Dynamic Card",
+      properties: %{},
+      uuid: UUID.uuid1(:hex),
+      classification: "latest",
+      image_url: "https://assets.highcharts.com/images/demo-thumbnails/highcharts/line-basic-default.png",
+      category: ["card", "dynamic_card"],
+      policies: %{},
+      widget_type_id: widget_type.id,
+      visual_settings: WidgetHelpers.do_settings(widget_settings, :visual, %CustomCards{}),
+      data_settings: WidgetHelpers.do_settings(widget_settings, :data, %CustomCards{}),
+      default_values: data
+    }
+  end
+end

--- a/apps/acqdat_core/priv/repo/seed/widgets/gauge_series.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/gauge_series.ex
@@ -5,6 +5,7 @@ defmodule AcqdatCore.Seed.Widgets.GaugeSeries do
   alias AcqdatCore.Repo
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
+  alias AcqdatCore.Widgets.Schema.Vendors.HighCharts
 
   @highchart_key_widget_settings %{
     gauge: %{
@@ -106,7 +107,7 @@ defmodule AcqdatCore.Seed.Widgets.GaugeSeries do
   }
 
   def seed() do
-    widget_type = WidgetHelpers.seed_widget_type()
+    widget_type = WidgetHelpers.find_or_create_widget_type("HighCharts")
     seed_widgets(widget_type)
   end
 
@@ -131,8 +132,8 @@ defmodule AcqdatCore.Seed.Widgets.GaugeSeries do
       category: ["chart", "gauge"],
       policies: %{},
       widget_type_id: widget_type.id,
-      visual_settings: WidgetHelpers.do_settings(widget_settings, :visual),
-      data_settings: WidgetHelpers.do_settings(widget_settings, :data),
+      visual_settings: WidgetHelpers.do_settings(widget_settings, :visual, %HighCharts{}),
+      data_settings: WidgetHelpers.do_settings(widget_settings, :data, %HighCharts{}),
       default_values: data
     }
   end

--- a/apps/acqdat_core/priv/repo/seed/widgets/image_card.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/image_card.ex
@@ -1,0 +1,59 @@
+defmodule AcqdatCore.Seed.Widgets.ImageCard do
+  @moduledoc """
+  Holds seeds for DynamicCard widgets.
+  """
+  alias AcqdatCore.Repo
+  alias AcqdatCore.Seed.Helpers.WidgetHelpers
+  alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
+  alias AcqdatCore.Widgets.Schema.Vendors.CustomCards
+
+  @custom_card_key_widget_settings %{
+    card: %{
+      visual: %{
+        card: [type: %{value: "image card"}, backgroundColor: %{}, font: %{}],
+        title: [text: %{}, align: %{}],
+        icon: [text: %{}, align: %{}]
+      }
+    }
+  }
+
+  @custom_card_value_settings %{
+    card: %{
+      visual_setting_values: %{
+        title: %{text: "Higchart Image"},
+        icon: %{text: "https://assets.highcharts.com/images/demo-thumbnails/highcharts/line-basic-default.png"}
+      }
+    }
+  }
+
+  def seed() do
+    widget_type = WidgetHelpers.find_or_create_widget_type("CustomCards")
+    seed_widgets(widget_type)
+  end
+
+  def seed_widgets(widget_type) do
+    @custom_card_key_widget_settings
+    |> Enum.map(fn {key, widget_settings} ->
+      set_widget_data(key, widget_settings, @custom_card_value_settings[key],
+        widget_type)
+    end)
+    |> Enum.each(fn data ->
+      Repo.insert!(data)
+    end)
+  end
+
+  def set_widget_data(_key, widget_settings, data, widget_type) do
+    %WidgetSchema{
+      label: "Image Card",
+      properties: %{},
+      uuid: UUID.uuid1(:hex),
+      classification: "standard",
+      image_url: "https://assets.highcharts.com/images/demo-thumbnails/highcharts/line-basic-default.png",
+      category: ["card", "image_card"],
+      policies: %{},
+      widget_type_id: widget_type.id,
+      visual_settings: WidgetHelpers.do_settings(widget_settings, :visual, %CustomCards{}),
+      default_values: data
+    }
+  end
+end

--- a/apps/acqdat_core/priv/repo/seed/widgets/line.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/line.ex
@@ -5,6 +5,7 @@ defmodule AcqdatCore.Seed.Widgets.Line do
   alias AcqdatCore.Repo
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
+  alias AcqdatCore.Widgets.Schema.Vendors.HighCharts
 
   @highchart_key_widget_settings %{
     line: %{
@@ -80,7 +81,7 @@ defmodule AcqdatCore.Seed.Widgets.Line do
   }
 
   def seed() do
-    widget_type = WidgetHelpers.seed_widget_type()
+    widget_type = WidgetHelpers.find_or_create_widget_type("HighCharts")
     seed_widgets(widget_type)
   end
 
@@ -105,8 +106,8 @@ defmodule AcqdatCore.Seed.Widgets.Line do
       category: ["chart", "line"],
       policies: %{},
       widget_type_id: widget_type.id,
-      visual_settings: WidgetHelpers.do_settings(widget_settings, :visual),
-      data_settings: WidgetHelpers.do_settings(widget_settings, :data),
+      visual_settings: WidgetHelpers.do_settings(widget_settings, :visual, %HighCharts{}),
+      data_settings: WidgetHelpers.do_settings(widget_settings, :data, %HighCharts{}),
       default_values: data
     }
   end

--- a/apps/acqdat_core/priv/repo/seed/widgets/line_timeseries.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/line_timeseries.ex
@@ -5,6 +5,7 @@ defmodule AcqdatCore.Seed.Widgets.LineTimeseries do
   alias AcqdatCore.Repo
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
+  alias AcqdatCore.Widgets.Schema.Vendors.HighCharts
 
   @highchart_key_widget_settings %{
     line: %{
@@ -81,7 +82,7 @@ defmodule AcqdatCore.Seed.Widgets.LineTimeseries do
   }
 
   def seed() do
-    widget_type = WidgetHelpers.seed_widget_type()
+    widget_type = WidgetHelpers.find_or_create_widget_type("HighCharts")
     seed_widgets(widget_type)
   end
 
@@ -106,8 +107,8 @@ defmodule AcqdatCore.Seed.Widgets.LineTimeseries do
       category: ["chart", "line"],
       policies: %{},
       widget_type_id: widget_type.id,
-      visual_settings: WidgetHelpers.do_settings(widget_settings, :visual),
-      data_settings: WidgetHelpers.do_settings(widget_settings, :data),
+      visual_settings: WidgetHelpers.do_settings(widget_settings, :visual, %HighCharts{}),
+      data_settings: WidgetHelpers.do_settings(widget_settings, :data, %HighCharts{}),
       default_values: data
     }
   end

--- a/apps/acqdat_core/priv/repo/seed/widgets/pie.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/pie.ex
@@ -5,6 +5,7 @@ defmodule AcqdatCore.Seed.Widgets.Pie do
   alias AcqdatCore.Repo
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
+  alias AcqdatCore.Widgets.Schema.Vendors.HighCharts
 
   @highchart_key_widget_settings %{
     pie: %{
@@ -65,7 +66,7 @@ defmodule AcqdatCore.Seed.Widgets.Pie do
   }
 
   def seed() do
-    widget_type = WidgetHelpers.return_widget_type()
+    widget_type = WidgetHelpers.find_or_create_widget_type("HighCharts")
     seed_widgets(widget_type)
   end
 
@@ -90,8 +91,8 @@ defmodule AcqdatCore.Seed.Widgets.Pie do
       category: ["chart", "pie"],
       policies: %{},
       widget_type_id: widget_type.id,
-      visual_settings: WidgetHelpers.do_settings(widget_settings, :visual),
-      data_settings: WidgetHelpers.do_settings(widget_settings, :data),
+      visual_settings: WidgetHelpers.do_settings(widget_settings, :visual, %HighCharts{}),
+      data_settings: WidgetHelpers.do_settings(widget_settings, :data, %HighCharts{}),
       default_values: data
     }
   end

--- a/apps/acqdat_core/priv/repo/seed/widgets/solid_gauge.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/solid_gauge.ex
@@ -5,6 +5,7 @@ defmodule AcqdatCore.Seed.Widgets.SolidGauge do
   alias AcqdatCore.Repo
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
+  alias AcqdatCore.Widgets.Schema.Vendors.HighCharts
 
   @highchart_key_widget_settings %{
     solidgauge: %{
@@ -84,7 +85,7 @@ defmodule AcqdatCore.Seed.Widgets.SolidGauge do
   }
 
   def seed() do
-    widget_type = WidgetHelpers.seed_widget_type()
+    widget_type = WidgetHelpers.find_or_create_widget_type("HighCharts")
     seed_widgets(widget_type)
   end
 
@@ -109,8 +110,8 @@ defmodule AcqdatCore.Seed.Widgets.SolidGauge do
       category: ["chart", "solid gauge"],
       policies: %{},
       widget_type_id: widget_type.id,
-      visual_settings: WidgetHelpers.do_settings(widget_settings, :visual),
-      data_settings: WidgetHelpers.do_settings(widget_settings, :data),
+      visual_settings: WidgetHelpers.do_settings(widget_settings, :visual, %HighCharts{}),
+      data_settings: WidgetHelpers.do_settings(widget_settings, :data, %HighCharts{}),
       default_values: data
     }
   end

--- a/apps/acqdat_core/priv/repo/seed/widgets/static_card.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/static_card.ex
@@ -1,0 +1,59 @@
+defmodule AcqdatCore.Seed.Widgets.StaticCard do
+  @moduledoc """
+  Holds seeds for StaticCard widgets.
+  """
+  alias AcqdatCore.Repo
+  alias AcqdatCore.Seed.Helpers.WidgetHelpers
+  alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
+  alias AcqdatCore.Widgets.Schema.Vendors.CustomCards
+
+  @custom_card_key_widget_settings %{
+    card: %{
+      visual: %{
+        card: [type: %{value: "static card"}, backgroundColor: %{}, font: %{}],
+        title: [text: %{}, align: %{}],
+        description: [text: %{}, align: %{}]
+      }
+    }
+  }
+
+  @custom_card_value_settings %{
+    card: %{
+      visual_setting_values: %{
+        title: %{text: "Smart Meter A"},
+        description: %{text: "Smart Meter A"}
+      }
+    }
+  }
+
+  def seed() do
+    widget_type = WidgetHelpers.find_or_create_widget_type("CustomCards")
+    seed_widgets(widget_type)
+  end
+
+  def seed_widgets(widget_type) do
+    @custom_card_key_widget_settings
+    |> Enum.map(fn {key, widget_settings} ->
+      set_widget_data(key, widget_settings, @custom_card_value_settings[key],
+        widget_type)
+    end)
+    |> Enum.each(fn data ->
+      Repo.insert!(data)
+    end)
+  end
+
+  def set_widget_data(_key, widget_settings, data, widget_type) do
+    %WidgetSchema{
+      label: "Static Card",
+      properties: %{},
+      uuid: UUID.uuid1(:hex),
+      classification: "standard",
+      image_url: "https://assets.highcharts.com/images/demo-thumbnails/highcharts/line-basic-default.png",
+      category: ["card", "static_card"],
+      policies: %{},
+      widget_type_id: widget_type.id,
+      visual_settings: WidgetHelpers.do_settings(widget_settings, :visual, %CustomCards{}),
+      default_values: data
+    }
+  end
+end

--- a/apps/acqdat_core/priv/repo/seed/widgets/stock_single_line.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/stock_single_line.ex
@@ -5,6 +5,7 @@ defmodule AcqdatCore.Seed.Widgets.StockSingleLine do
   alias AcqdatCore.Repo
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
+  alias AcqdatCore.Widgets.Schema.Vendors.HighCharts
 
   @highchart_key_widget_settings %{
     line: %{
@@ -62,7 +63,7 @@ defmodule AcqdatCore.Seed.Widgets.StockSingleLine do
   }
 
   def seed() do
-    widget_type = WidgetHelpers.seed_widget_type()
+    widget_type = WidgetHelpers.find_or_create_widget_type("HighCharts")
     seed_widgets(widget_type)
   end
 
@@ -86,8 +87,8 @@ defmodule AcqdatCore.Seed.Widgets.StockSingleLine do
       category: ["stock_chart", "line"],
       policies: %{},
       widget_type_id: widget_type.id,
-      visual_settings: WidgetHelpers.do_settings(widget_settings, :visual),
-      data_settings: WidgetHelpers.do_settings(widget_settings, :data),
+      visual_settings: WidgetHelpers.do_settings(widget_settings, :visual, %HighCharts{}),
+      data_settings: WidgetHelpers.do_settings(widget_settings, :data, %HighCharts{}),
       default_values: data
     }
   end

--- a/apps/acqdat_core/test/dashboard_management/model/command_widget_test.exs
+++ b/apps/acqdat_core/test/dashboard_management/model/command_widget_test.exs
@@ -6,20 +6,20 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidgetTest do
 
   describe "create/1 " do
     setup do
-      dashboard = insert(:dashboard)
+      panel = insert(:panel)
       gateway = insert(:gateway)
 
-      [gateway: gateway, dashboard: dashboard]
+      [gateway: gateway, panel: panel]
     end
 
     test "creates a command widget with supplied params", context do
-      %{gateway: gateway, dashboard: dashboard} = context
+      %{gateway: gateway, panel: panel} = context
       module = "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl"
       data_settings = setup_data()
 
       params = %{
         gateway_id: gateway.id,
-        dashboard_id: dashboard.id,
+        panel_id: panel.id,
         module: module,
         data_settings: data_settings,
         visual_settings: %{},
@@ -32,20 +32,20 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidgetTest do
 
   describe "update/2 " do
     setup do
-      dashboard = insert(:dashboard)
+      panel = insert(:panel)
       gateway = insert(:gateway)
 
-      [gateway: gateway, dashboard: dashboard]
+      [gateway: gateway, panel: panel]
     end
 
     test "update without data settings", context do
-      %{gateway: gateway, dashboard: dasbhoard} = context
+      %{gateway: gateway, panel: panel} = context
       module = "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl"
       data_settings = setup_data()
 
       params = %{
         "gateway_id" => gateway.id,
-        "dashboard_id" => dasbhoard.id,
+        "panel_id" => panel.id,
         "module" => module,
         "data_settings" => data_settings,
         "visual_settings" => %{},
@@ -62,13 +62,13 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidgetTest do
 
     # TODO add mock for mqtt
     test "update with data settings", context do
-      %{gateway: gateway, dashboard: dasbhoard} = context
+      %{gateway: gateway, panel: panel} = context
       module = "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl"
       data_settings = setup_data()
 
       params = %{
         "gateway_id" => gateway.id,
-        "dashboard_id" => dasbhoard.id,
+        "panel_id" => panel.id,
         "module" => module,
         "data_settings" => data_settings,
         "visual_settings" => %{},
@@ -87,8 +87,8 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidgetTest do
 
   describe "get/1 " do
     setup do
-      dashboard = insert(:dashboard)
-      command_widgets = insert_list(3, :command_widget, dashboard: dashboard)
+      panel = insert(:panel)
+      command_widgets = insert_list(3, :command_widget, panel: panel)
       [command_widgets: command_widgets]
     end
 
@@ -105,22 +105,22 @@ defmodule AcqdatCore.Model.DashboardManagement.CommandWidgetTest do
     end
   end
 
-  describe "get_all_by_dashboard_id/1 " do
+  describe "get_all_by_panel_id/1 " do
     setup do
-      dashboard = insert(:dashboard)
-      command_widgets = insert_list(3, :command_widget, dashboard: dashboard)
+      panel = insert(:panel)
+      command_widgets = insert_list(3, :command_widget, panel: panel)
       [command_widgets: command_widgets]
     end
 
     test "returns command widget with id", context do
       %{command_widgets: [cw1, _cw_2, _cw_3]} = context
-      widgets = CommandWidget.get_all_by_dashboard_id(cw1.dashboard_id)
+      widgets = CommandWidget.get_all_by_panel_id(cw1.panel_id)
       assert length(widgets) == 3
     end
 
     test "returns empty if none found" do
-      dashboard = insert(:dashboard)
-      widgets = CommandWidget.get_all_by_dashboard_id(dashboard.id)
+      panel = insert(:panel)
+      widgets = CommandWidget.get_all_by_panel_id(panel.id)
       assert widgets == []
     end
   end

--- a/apps/acqdat_core/test/dashboard_management/model/dashboard_test.exs
+++ b/apps/acqdat_core/test/dashboard_management/model/dashboard_test.exs
@@ -1,0 +1,134 @@
+defmodule AcqdatCore.Model.DashboardManagement.DashboardTest do
+  use ExUnit.Case, async: true
+  use AcqdatCore.DataCase
+  import AcqdatCore.Support.Factory
+  alias AcqdatCore.Repo
+  alias AcqdatCore.Model.DashboardManagement.Dashboard, as: DashboardModel
+  alias AcqdatCore.DashboardManagement.Schema.Panel
+  alias AcqdatCore.Model.DashboardManagement.Panel, as: PanelModel
+
+  describe "get_by_id/1" do
+    test "returns a particular dashboard" do
+      dashboard = insert(:dashboard)
+      {:ok, result} = DashboardModel.get_by_id(dashboard.id)
+
+      assert not is_nil(result)
+      assert result.id == dashboard.id
+    end
+
+    test "returns error not found, if dashboard is not present" do
+      {:error, result} = DashboardModel.get_by_id(-1)
+      assert result == "dashboard with this id not found"
+    end
+  end
+
+  describe "get_with_panels/1" do
+    test "returns a particular dashboard with its panels" do
+      panel = insert(:panel)
+      {:ok, result} = DashboardModel.get_with_panels(panel.dashboard_id)
+
+      assert not is_nil(result)
+      assert result.id == panel.dashboard_id
+      assert not is_nil(length(result.panels))
+    end
+
+    test "returns error not found, if dashboard is not present" do
+      {:error, result} = DashboardModel.get_with_panels(-1)
+      assert result == "dashboard with this id not found"
+    end
+  end
+
+  describe "get_all/1" do
+    test "returns all dashboards" do
+      dashboard = insert(:dashboard)
+
+      result =
+        DashboardModel.get_all(%{
+          page_size: 10,
+          page_number: 1,
+          org_id: dashboard.org_id
+        })
+
+      assert not is_nil(result)
+      assert length(result.entries) == 1
+    end
+  end
+
+  describe "create/1" do
+    setup do
+      organisation = insert(:organisation)
+      [organisation: organisation]
+    end
+
+    test "creates a dashboard with supplied params", context do
+      %{organisation: organisation} = context
+
+      params = %{
+        name: "Demo Dashboard",
+        org_id: organisation.id
+      }
+
+      assert {:ok, _dashboard} = DashboardModel.create(params)
+    end
+
+    test "fails if organisation_id is not present", context do
+      params = %{
+        name: "Demo Dashboard"
+      }
+
+      assert {:error, changeset} = DashboardModel.create(params)
+      assert %{org_id: ["can't be blank"]} == errors_on(changeset)
+    end
+
+    test "fails if name is not present", context do
+      %{organisation: organisation} = context
+
+      params = %{
+        org_id: organisation.id
+      }
+
+      assert {:error, changeset} = DashboardModel.create(params)
+      assert %{name: ["can't be blank"]} == errors_on(changeset)
+    end
+  end
+
+  describe "update/1" do
+    setup do
+      dashboard = insert(:dashboard)
+      [dashboard: dashboard]
+    end
+
+    test "creates a dashboard with supplied params", context do
+      %{dashboard: dashboard} = context
+
+      params = %{
+        name: "updated Demo Dashboard"
+      }
+
+      assert {:ok, _dashboard} = DashboardModel.update(dashboard, params)
+    end
+  end
+
+  describe "delete/1" do
+    test "deletes a particular dashboard and its associated panels" do
+      dashboard = insert(:dashboard)
+      widget = insert(:widget)
+
+      {:ok, panel} =
+        PanelModel.create(%{
+          name: "Home",
+          dashboard_id: dashboard.id,
+          widget_id: widget.id,
+          org_id: dashboard.org_id
+        })
+
+      {:ok, result} = DashboardModel.delete(dashboard)
+
+      panel = Repo.get(Panel, panel.id)
+
+      assert not is_nil(result)
+      assert result.id == dashboard.id
+      assert is_nil(panel)
+    end
+  end
+end

--- a/apps/acqdat_core/test/dashboard_management/model/panel_test.exs
+++ b/apps/acqdat_core/test/dashboard_management/model/panel_test.exs
@@ -1,0 +1,147 @@
+defmodule AcqdatCore.Model.DashboardManagement.PanelTest do
+  use ExUnit.Case, async: true
+  use AcqdatCore.DataCase
+  import AcqdatCore.Support.Factory
+  alias AcqdatCore.Repo
+  alias AcqdatCore.Model.DashboardManagement.Panel, as: PanelModel
+  alias AcqdatCore.DashboardManagement.Schema.WidgetInstance
+  alias AcqdatCore.Model.DashboardManagement.WidgetInstance, as: WidgetInstanceModel
+
+  describe "get_by_id/1" do
+    test "returns a particular panel" do
+      panel = insert(:panel)
+      {:ok, result} = PanelModel.get_by_id(panel.id)
+
+      assert not is_nil(result)
+      assert result.id == panel.id
+    end
+
+    test "returns error not found, if panel is not present" do
+      {:error, result} = PanelModel.get_by_id(-1)
+      assert result == "panel with this id not found"
+    end
+  end
+
+  describe "get_with_widgtes/1" do
+    test "returns a particular panel with its widgets" do
+      widget_instance = insert(:widget_instance)
+      {:ok, result} = PanelModel.get_with_widgets(widget_instance.panel_id)
+
+      assert not is_nil(result)
+      assert result.id == widget_instance.panel_id
+      assert not is_nil(length(result.widgets))
+    end
+
+    test "returns error not found, if panel is not present" do
+      {:error, result} = PanelModel.get_with_widgets(-1)
+      assert result == "panel with this id not found"
+    end
+  end
+
+  describe "get_all/1" do
+    test "returns all panels" do
+      panel = insert(:panel)
+
+      result =
+        PanelModel.get_all(%{
+          page_size: 10,
+          page_number: 1,
+          org_id: panel.org_id,
+          dashboard_id: panel.dashboard_id
+        })
+
+      assert not is_nil(result)
+      assert length(result.entries) == 1
+    end
+  end
+
+  describe "create/1" do
+    setup do
+      organisation = insert(:organisation)
+      dashboard = insert(:dashboard)
+      [organisation: organisation, dashboard: dashboard]
+    end
+
+    test "creates a panel with supplied params", context do
+      %{organisation: organisation, dashboard: dashboard} = context
+
+      params = %{
+        name: "Demo panel",
+        org_id: organisation.id,
+        dashboard_id: dashboard.id
+      }
+
+      assert {:ok, _panel} = PanelModel.create(params)
+    end
+
+    test "fails if organisation_id is not present", %{dashboard: dashboard} do
+      params = %{
+        name: "Demo panel",
+        dashboard_id: dashboard.id
+      }
+
+      assert {:error, changeset} = PanelModel.create(params)
+      assert %{org_id: ["can't be blank"]} == errors_on(changeset)
+    end
+
+    test "fails if dashboard_id is not present", %{organisation: organisation} do
+      params = %{
+        name: "Demo panel",
+        org_id: organisation.id
+      }
+
+      assert {:error, changeset} = PanelModel.create(params)
+      assert %{dashboard_id: ["can't be blank"]} == errors_on(changeset)
+    end
+
+    test "fails if name is not present", context do
+      %{organisation: organisation, dashboard: dashboard} = context
+
+      params = %{
+        org_id: organisation.id,
+        dashboard_id: dashboard.id
+      }
+
+      assert {:error, changeset} = PanelModel.create(params)
+      assert %{name: ["can't be blank"]} == errors_on(changeset)
+    end
+  end
+
+  describe "update/1" do
+    setup do
+      panel = insert(:panel)
+      [panel: panel]
+    end
+
+    test "updates a panel with supplied params", context do
+      %{panel: panel} = context
+
+      params = %{
+        name: "updated Demo panel"
+      }
+
+      assert {:ok, _panel} = PanelModel.update(panel, params)
+    end
+  end
+
+  describe "delete/1" do
+    test "deletes a particular panel and its associated widgets" do
+      panel = insert(:panel)
+      widget = insert(:widget)
+
+      {:ok, widget_inst} =
+        WidgetInstanceModel.create(%{
+          label: "widget_instance",
+          panel_id: panel.id,
+          widget_id: widget.id
+        })
+
+      {no_of_deleted_records, _} = PanelModel.delete_all([panel.id])
+
+      widget_instance = Repo.get(WidgetInstance, widget_inst.id)
+
+      assert no_of_deleted_records == 1
+      assert is_nil(widget_instance)
+    end
+  end
+end

--- a/apps/acqdat_core/test/dashboard_management/model/widget_instance_test.exs
+++ b/apps/acqdat_core/test/dashboard_management/model/widget_instance_test.exs
@@ -4,7 +4,6 @@ defmodule AcqdatCore.Model.DashboardManagement.WidgetInstanceTest do
   import AcqdatCore.Support.Factory
   alias AcqdatCore.Repo
   alias AcqdatCore.Model.DashboardManagement.WidgetInstance, as: WidgetInstanceModel
-  alias AcqdatCore.DashboardManagement.Schema.WidgetInstance
   alias AcqdatCore.Model.EntityManagement.SensorData, as: SensorDataModel
 
   describe "get_by_filter" do
@@ -74,10 +73,10 @@ defmodule AcqdatCore.Model.DashboardManagement.WidgetInstanceTest do
     end
   end
 
-  describe "get_all_by_dashboard_id" do
-    test "returns all widget_instances of respective dashboard" do
+  describe "get_all_by_panel_id" do
+    test "returns all widget_instances of respective panel" do
       widget = insert(:widget_instance)
-      result = WidgetInstanceModel.get_all_by_dashboard_id(widget.dashboard_id)
+      result = WidgetInstanceModel.get_all_by_panel_id(widget.panel_id)
 
       assert not is_nil(result)
       assert length(result) == 1
@@ -86,24 +85,24 @@ defmodule AcqdatCore.Model.DashboardManagement.WidgetInstanceTest do
 
   describe "create/1" do
     setup do
-      dashboard = insert(:dashboard)
+      panel = insert(:panel)
       widget = insert(:widget)
-      [dashboard: dashboard, widget: widget]
+      [panel: panel, widget: widget]
     end
 
     test "creates a widget_instance with supplied params", context do
-      %{dashboard: dashboard, widget: widget} = context
+      %{panel: panel, widget: widget} = context
 
       params = %{
         label: "Demo WidgetInstance",
         widget_id: widget.id,
-        dashboard_id: dashboard.id
+        panel_id: panel.id
       }
 
       assert {:ok, _widget_instance} = WidgetInstanceModel.create(params)
     end
 
-    test "fails if dashboard_id is not present", context do
+    test "fails if panel_id is not present", context do
       %{widget: widget} = context
 
       params = %{
@@ -112,15 +111,15 @@ defmodule AcqdatCore.Model.DashboardManagement.WidgetInstanceTest do
       }
 
       assert {:error, changeset} = WidgetInstanceModel.create(params)
-      assert %{dashboard_id: ["can't be blank"]} == errors_on(changeset)
+      assert %{panel_id: ["can't be blank"]} == errors_on(changeset)
     end
 
     test "fails if label is not present", context do
-      %{dashboard: dashboard, widget: widget} = context
+      %{panel: panel, widget: widget} = context
 
       params = %{
         widget_id: widget.id,
-        dashboard_id: dashboard.id
+        panel_id: panel.id
       }
 
       assert {:error, changeset} = WidgetInstanceModel.create(params)
@@ -128,11 +127,11 @@ defmodule AcqdatCore.Model.DashboardManagement.WidgetInstanceTest do
     end
 
     test "fails if widget is not present", context do
-      %{dashboard: dashboard} = context
+      %{panel: panel} = context
 
       params = %{
         label: "Demo WidgetInstance",
-        dashboard_id: dashboard.id
+        panel_id: panel.id
       }
 
       assert {:error, changeset} = WidgetInstanceModel.create(params)

--- a/apps/acqdat_core/test/dashboard_management/schema/command_widget_test.exs
+++ b/apps/acqdat_core/test/dashboard_management/schema/command_widget_test.exs
@@ -6,21 +6,21 @@ defmodule AcqdatCore.DashboardManagement.Schema.CommandWidgetTest do
 
   describe "changeset" do
     setup do
-      dashboard = insert(:dashboard)
+      panel = insert(:panel)
       gateway = insert(:gateway)
 
-      [gateway: gateway, dashboard: dashboard]
+      [gateway: gateway, panel: panel]
     end
 
     test "returns a valid changeset", context do
-      %{dashboard: dashboard, gateway: gateway} = context
+      %{panel: panel, gateway: gateway} = context
       module = "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl"
 
       params = %{
         label: "LED CONTROL WIDGET",
         module: module,
         gateway_id: gateway.id,
-        dashboard_id: dashboard.id
+        panel_id: panel.id
       }
 
       %{valid?: validity} = CommandWidget.changeset(%CommandWidget{}, params)
@@ -32,7 +32,7 @@ defmodule AcqdatCore.DashboardManagement.Schema.CommandWidgetTest do
       changeset = CommandWidget.changeset(%CommandWidget{}, params)
 
       assert errors_on(changeset) == %{
-               dashboard_id: ["can't be blank"],
+               panel_id: ["can't be blank"],
                gateway_id: ["can't be blank"],
                label: ["can't be blank"],
                module: ["can't be blank"]
@@ -40,14 +40,14 @@ defmodule AcqdatCore.DashboardManagement.Schema.CommandWidgetTest do
     end
 
     test "fails for invalid associations", context do
-      %{dashboard: dashboard, gateway: gateway} = context
+      %{panel: panel, gateway: gateway} = context
       module = "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl"
 
       params = %{
         label: "LED CONTROL WIDGET",
         module: module,
         gateway_id: -1,
-        dashboard_id: dashboard.id
+        panel_id: panel.id
       }
 
       changeset = CommandWidget.changeset(%CommandWidget{}, params)
@@ -59,13 +59,13 @@ defmodule AcqdatCore.DashboardManagement.Schema.CommandWidgetTest do
         label: "LED CONTROL WIDGET",
         module: module,
         gateway_id: gateway.id,
-        dashboard_id: -1
+        panel_id: -1
       }
 
       changeset = CommandWidget.changeset(%CommandWidget{}, params)
 
       {:error, changeset} = Repo.insert(changeset)
-      assert errors_on(changeset) == %{dashboard: ["does not exist"]}
+      assert errors_on(changeset) == %{panel: ["does not exist"]}
     end
   end
 end

--- a/apps/acqdat_core/test/dashboard_management/schema/panel_test.exs
+++ b/apps/acqdat_core/test/dashboard_management/schema/panel_test.exs
@@ -1,0 +1,102 @@
+defmodule AcqdatCore.Schema.DashboardManagement.PanelTest do
+  use ExUnit.Case, async: true
+  use AcqdatCore.DataCase
+  import AcqdatCore.Support.Factory
+  alias AcqdatCore.DashboardManagement.Schema.Panel
+
+  describe "changeset/2" do
+    setup do
+      organisation = insert(:organisation)
+      dashboard = insert(:dashboard)
+      [organisation: organisation, dashboard: dashboard]
+    end
+
+    test "returns a valid changeset", context do
+      %{organisation: organisation, dashboard: dashboard} = context
+
+      params = %{
+        name: "Demo Panel",
+        org_id: organisation.id,
+        dashboard_id: dashboard.id
+      }
+
+      %{valid?: validity} = Panel.changeset(%Panel{}, params)
+      assert validity
+    end
+
+    test "returns invalid if params empty" do
+      %{valid?: validity} = changeset = Panel.changeset(%Panel{}, %{})
+      refute validity
+
+      assert %{
+               org_id: ["can't be blank"],
+               dashboard_id: ["can't be blank"],
+               name: ["can't be blank"]
+             } = errors_on(changeset)
+    end
+
+    test "returns error if Panel name is not presenet", %{
+      organisation: organisation,
+      dashboard: dashboard
+    } do
+      params = %{
+        org_id: organisation.id,
+        dashboard_id: dashboard.id
+      }
+
+      changeset = Panel.changeset(%Panel{}, params)
+
+      {:error, result_changeset} = Repo.insert(changeset)
+      assert %{name: ["can't be blank"]} == errors_on(result_changeset)
+    end
+
+    test "returns error if organisation assoc constraint not satisfied", %{
+      dashboard: dashboard
+    } do
+      params = %{
+        name: "Demo Panel",
+        org_id: -1,
+        dashboard_id: dashboard.id
+      }
+
+      changeset = Panel.changeset(%Panel{}, params)
+
+      {:error, result_changeset} = Repo.insert(changeset)
+      assert %{org: ["does not exist"]} == errors_on(result_changeset)
+    end
+
+    test "returns error if dashboard assoc constraint not satisfied", %{
+      organisation: organisation
+    } do
+      params = %{
+        name: "Demo Panel",
+        org_id: organisation.id,
+        dashboard_id: -1
+      }
+
+      changeset = Panel.changeset(%Panel{}, params)
+
+      {:error, result_changeset} = Repo.insert(changeset)
+      assert %{dashboard: ["does not exist"]} == errors_on(result_changeset)
+    end
+
+    test "returns error if unique name constraint not satisified under dashboard", %{
+      organisation: organisation,
+      dashboard: dashboard
+    } do
+      params = %{
+        name: "Demo Panel",
+        org_id: organisation.id,
+        dashboard_id: dashboard.id
+      }
+
+      changeset = Panel.changeset(%Panel{}, params)
+
+      Repo.insert(changeset)
+
+      new_changeset = Panel.changeset(%Panel{}, params)
+      {:error, result_changeset} = Repo.insert(new_changeset)
+      assert %{name: ["unique panel name under dashboard"]} == errors_on(result_changeset)
+    end
+  end
+end

--- a/apps/acqdat_core/test/dashboard_management/schema/widget_instance_test.exs
+++ b/apps/acqdat_core/test/dashboard_management/schema/widget_instance_test.exs
@@ -7,17 +7,17 @@ defmodule AcqdatCore.Schema.DashboardManagement.WidgetInstanceTest do
   describe "changeset/2" do
     setup do
       widget = insert(:widget)
-      dashboard = insert(:dashboard)
-      [widget: widget, dashboard: dashboard]
+      panel = insert(:panel)
+      [widget: widget, panel: panel]
     end
 
     test "returns a valid changeset", context do
-      %{widget: widget, dashboard: dashboard} = context
+      %{widget: widget, panel: panel} = context
 
       params = %{
         label: "Demo WidgetInstance",
         widget_id: widget.id,
-        dashboard_id: dashboard.id
+        panel_id: panel.id
       }
 
       %{valid?: validity} = WidgetInstance.changeset(%WidgetInstance{}, params)
@@ -29,16 +29,16 @@ defmodule AcqdatCore.Schema.DashboardManagement.WidgetInstanceTest do
       refute validity
 
       assert %{
-               dashboard_id: ["can't be blank"],
+               panel_id: ["can't be blank"],
                label: ["can't be blank"],
                widget_id: ["can't be blank"]
              } = errors_on(changeset)
     end
 
-    test "returns error if label is not presenet", %{widget: widget, dashboard: dashboard} do
+    test "returns error if label is not presenet", %{widget: widget, panel: panel} do
       params = %{
         widget_id: widget.id,
-        dashboard_id: dashboard.id
+        panel_id: panel.id
       }
 
       changeset = WidgetInstance.changeset(%WidgetInstance{}, params)
@@ -47,11 +47,11 @@ defmodule AcqdatCore.Schema.DashboardManagement.WidgetInstanceTest do
       assert %{label: ["can't be blank"]} == errors_on(result_changeset)
     end
 
-    test "returns error if widget assoc constraint not satisfied", %{dashboard: dashboard} do
+    test "returns error if widget assoc constraint not satisfied", %{panel: panel} do
       params = %{
         label: "Demo WidgetInstance",
         widget_id: -1,
-        dashboard_id: dashboard.id
+        panel_id: panel.id
       }
 
       changeset = WidgetInstance.changeset(%WidgetInstance{}, params)
@@ -60,27 +60,27 @@ defmodule AcqdatCore.Schema.DashboardManagement.WidgetInstanceTest do
       assert %{widget: ["does not exist"]} == errors_on(result_changeset)
     end
 
-    test "returns error if dashboard assoc constraint not satisfied", %{widget: widget} do
+    test "returns error if panel assoc constraint not satisfied", %{widget: widget} do
       params = %{
         label: "Demo WidgetInstance",
         widget_id: widget.id,
-        dashboard_id: -1
+        panel_id: -1
       }
 
       changeset = WidgetInstance.changeset(%WidgetInstance{}, params)
 
       {:error, result_changeset} = Repo.insert(changeset)
-      assert %{dashboard: ["does not exist"]} == errors_on(result_changeset)
+      assert %{panel: ["does not exist"]} == errors_on(result_changeset)
     end
 
     test "returns error if unique label constraint not satisified", %{
       widget: widget,
-      dashboard: dashboard
+      panel: panel
     } do
       params = %{
         label: "Demo WidgetInstance",
         widget_id: widget.id,
-        dashboard_id: dashboard.id
+        panel_id: panel.id
       }
 
       changeset = WidgetInstance.changeset(%WidgetInstance{}, params)
@@ -89,7 +89,9 @@ defmodule AcqdatCore.Schema.DashboardManagement.WidgetInstanceTest do
 
       new_changeset = WidgetInstance.changeset(%WidgetInstance{}, params)
       {:error, result_changeset} = Repo.insert(new_changeset)
-      assert %{label: ["unique widget label under dashboard"]} == errors_on(result_changeset)
+
+      assert %{label: ["unique widget label under dashboard's panel"]} ==
+               errors_on(result_changeset)
     end
   end
 end

--- a/apps/acqdat_core/test/support/factory/factory.ex
+++ b/apps/acqdat_core/test/support/factory/factory.ex
@@ -149,7 +149,7 @@ defmodule AcqdatCore.Support.Factory do
   def widget_type_factory() do
     %WidgetType{
       name: sequence(:name, &"Widget_Type-#{&1}"),
-      vendor: "Highcharts",
+      vendor: "HighCharts",
       module: "Elixir.AcqdatCore.Widgets.Schema.Vendors.HighCharts",
       vendor_metadata: %{}
     }

--- a/apps/acqdat_core/test/support/factory/factory.ex
+++ b/apps/acqdat_core/test/support/factory/factory.ex
@@ -16,6 +16,7 @@ defmodule AcqdatCore.Support.Factory do
 
   alias AcqdatCore.DashboardManagement.Schema.{
     Dashboard,
+    Panel,
     WidgetInstance,
     CommandWidget
   }
@@ -111,6 +112,16 @@ defmodule AcqdatCore.Support.Factory do
     }
   end
 
+  def panel_factory() do
+    %Panel{
+      uuid: UUID.uuid1(:hex),
+      name: sequence(:dashboard_name, &"Panel#{&1}"),
+      slug: sequence(:dashboard_name, &"Panel#{&1}"),
+      dashboard: build(:dashboard),
+      org: build(:organisation)
+    }
+  end
+
   def command_widget_factory() do
     %CommandWidget{
       uuid: UUID.uuid1(:hex),
@@ -119,7 +130,7 @@ defmodule AcqdatCore.Support.Factory do
       module: "Elixir.AcqdatCore.DashboardManagement.Schema.CommandWidget.LEDControl",
       command_widget_type: "html",
       gateway: build(:gateway),
-      dashboard: build(:dashboard),
+      panel: build(:panel),
       data_settings: %{},
       visual_settings: %{}
     }
@@ -130,7 +141,7 @@ defmodule AcqdatCore.Support.Factory do
       uuid: UUID.uuid1(:hex),
       label: sequence(:widget_inst_name, &"WidgetInstance#{&1}"),
       slug: sequence(:widget_inst_name, &"WidgetInstance#{&1}"),
-      dashboard: build(:dashboard),
+      panel: build(:panel),
       widget: build(:widget)
     }
   end


### PR DESCRIPTION
**Why ?**

We need to group widgets on the dashboard using the concept of panels

**Story IDs:**

- S20U1T1 (4pt) | BE: Modify dashboard schema and migrations to involve panels
- S20U1T3 (6pt) | BE: Add API to perform CRUD for panels in the dashboard
- S20U5T1 (3pt) | BE: Businees logic to add image and other settings for dashboard
- S20U1T5 (4pt) | BE: Add API to list all panels
- S20U1T2 (4pt) | BE: Modify business logic to group widgets under a panel
- S20U1T4 (6pt) | BE: Modify APIs for dashboards while listing widgets and data
- S20U2T2 (6pt) | BE: Add support for showing card and table widgets
- S20U2T1 (8pt) | BE: Add business logic to handle data for widgets of different types

