### PR TITLE
Fixes/data cruncher tasks

### DIFF
--- a/apps/acqdat_api/lib/acqdat_api/data_cruncher/task_execute_worker.ex
+++ b/apps/acqdat_api/lib/acqdat_api/data_cruncher/task_execute_worker.ex
@@ -1,6 +1,7 @@
 defmodule AcqdatApi.DataCruncher.TaskExecuteWorker do
   use GenServer
   alias AcqdatCore.DataCruncher.Domain.Workflow
+  alias AcqdatCore.DataCruncher.Model.Task, as: TaskModel
   alias AcqdatCore.Repo
 
   def start_link(_) do
@@ -23,7 +24,8 @@ defmodule AcqdatApi.DataCruncher.TaskExecuteWorker do
       end)
 
     tasks |> Enum.map(fn task -> Task.await(task) end)
-    task = task |> Repo.preload(workflows: :temp_output)
+
+    {:ok, task} = TaskModel.get(task.id)
 
     AcqdatApiWeb.Endpoint.broadcast("tasks:#{task.id}", "out_put_res", %{data: task})
     {:noreply, task}

--- a/apps/acqdat_api/lib/acqdat_api_web/router.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/router.ex
@@ -103,7 +103,8 @@ defmodule AcqdatApiWeb.Router do
     resources "/components", DataCruncher.ComponentsController, only: [:index]
 
     resources "/users", RoleManagement.UserController, only: [:show, :update, :index, :delete] do
-      resources "/tasks", DataCruncher.TasksController, only: [:create, :index, :show, :delete]
+      resources "/tasks", DataCruncher.TasksController,
+        only: [:create, :index, :show, :update, :delete]
 
       resources "/settings", RoleManagement.UserSettingController,
         only: [:create, :update],

--- a/apps/acqdat_core/lib/acqdat_core/data_cruncher/domain/workflow.ex
+++ b/apps/acqdat_core/lib/acqdat_core/data_cruncher/domain/workflow.ex
@@ -59,7 +59,7 @@ defmodule AcqdatCore.DataCruncher.Domain.Workflow do
     end)
   end
 
-  defp generate_graph_data(%{input_data: input_data, id: worflow_id} = workflow) do
+  defp generate_graph_data(%{input_data: input_data, id: workflow_id} = workflow) do
     # TODO: Needs to refactor and test it out for multiple input data and nodes
     nodes =
       Enum.reduce(input_data, %{}, fn data, acc ->
@@ -72,7 +72,7 @@ defmodule AcqdatCore.DataCruncher.Domain.Workflow do
 
             res = [
               {
-                worflow_id,
+                workflow_id,
                 String.to_atom(node["inports"]),
                 stream_data
               }

--- a/apps/acqdat_core/lib/acqdat_core/data_cruncher/model/task.ex
+++ b/apps/acqdat_core/lib/acqdat_core/data_cruncher/model/task.ex
@@ -9,6 +9,11 @@ defmodule AcqdatCore.DataCruncher.Model.Task do
     Repo.insert(changeset)
   end
 
+  def update(task, params) do
+    changeset = Tasks.update_changeset(task, params)
+    Repo.update(changeset)
+  end
+
   def delete(task) do
     Repo.delete(task)
   end

--- a/apps/acqdat_core/lib/acqdat_core/data_cruncher/schema/task.ex
+++ b/apps/acqdat_core/lib/acqdat_core/data_cruncher/schema/task.ex
@@ -70,4 +70,18 @@ defmodule AcqdatCore.DataCruncher.Schema.Tasks do
     )
     |> cast_assoc(:workflows, with: &Workflow.changeset/2)
   end
+
+  def update_changeset(%__MODULE__{} = task, params) do
+    task
+    |> cast(params, @permitted)
+    |> assoc_constraint(:org)
+    |> assoc_constraint(:user)
+    |> validate_required(@required_params)
+    |> validate_inclusion(:type, @task_types)
+    |> unique_constraint(:name,
+      name: :unique_task_name_per_user_n_org,
+      message: "Task name should be uniq"
+    )
+    |> cast_assoc(:workflows, with: &Workflow.changeset/2)
+  end
 end

--- a/apps/acqdat_core/lib/acqdat_core/data_cruncher/schema/task.ex
+++ b/apps/acqdat_core/lib/acqdat_core/data_cruncher/schema/task.ex
@@ -64,6 +64,9 @@ defmodule AcqdatCore.DataCruncher.Schema.Tasks do
     |> add_uuid()
     |> validate_required(@required_params)
     |> validate_inclusion(:type, @task_types)
+    |> unique_constraint(:name,
+      name: :unique_task_name_per_user_n_org,
+      message: "Task name should be uniq")
     |> cast_assoc(:workflows, with: &Workflow.changeset/2)
   end
 end

--- a/apps/acqdat_core/lib/acqdat_core/data_cruncher/schema/task.ex
+++ b/apps/acqdat_core/lib/acqdat_core/data_cruncher/schema/task.ex
@@ -66,7 +66,8 @@ defmodule AcqdatCore.DataCruncher.Schema.Tasks do
     |> validate_inclusion(:type, @task_types)
     |> unique_constraint(:name,
       name: :unique_task_name_per_user_n_org,
-      message: "Task name should be uniq")
+      message: "Task name should be uniq"
+    )
     |> cast_assoc(:workflows, with: &Workflow.changeset/2)
   end
 end

--- a/apps/acqdat_core/priv/repo/migrations/20210106073427_add_unique_index_on_name_for_tasks.exs
+++ b/apps/acqdat_core/priv/repo/migrations/20210106073427_add_unique_index_on_name_for_tasks.exs
@@ -1,0 +1,7 @@
+defmodule AcqdatCore.Repo.Migrations.AddUniqueIndexOnNameForTasks do
+  use Ecto.Migration
+
+  def change do
+  	create unique_index("acqdat_tasks", [:name, :user_id, :org_id], name: :unique_task_name_per_user_n_org)
+  end
+end


### PR DESCRIPTION
**Changes**
-> Channel Task's workflow output not showing because of task preloading issue, fixed that
-> Added uniqueness validation on task's name per user and org
-> added separate endpoint for the task update