### PR TITLE
Problem with exported dashboard solved.

### DIFF
--- a/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/dashboard_controller.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/dashboard_controller.ex
@@ -191,58 +191,7 @@ defmodule AcqdatApiWeb.DashboardManagement.DashboardController do
     end
   end
 
-  def exported_dashboard(conn, params) do
-    case conn.status do
-      nil ->
-        exported_dashboard = conn.assigns.exported_dashboard
-
-        dashboard =
-          check_exported_dashboard(exported_dashboard.is_secure, params, exported_dashboard)
-
-        case dashboard do
-          {:ok, dashboard} ->
-            conn
-            |> put_status(200)
-            |> render("show.json", %{dashboard: dashboard})
-
-          {:error, message} ->
-            send_error(conn, 400, message)
-
-          nil ->
-            conn
-            |> send_error(401, "Unauthorized link")
-        end
-
-      401 ->
-        conn
-        |> send_error(401, "Unauthorized link")
-    end
-  end
-
   ############################# private functions ###########################
-
-  defp check_exported_dashboard(true, params, exported_dashboard) do
-    case check_password(params["password"], exported_dashboard.password) do
-      false ->
-        nil
-
-      true ->
-        Dashboard.get_by_uuid(exported_dashboard.dashboard_uuid)
-    end
-  end
-
-  defp check_exported_dashboard(false, params, exported_dashboard) do
-    Dashboard.get_by_uuid(exported_dashboard.dashboard_uuid)
-  end
-
-  defp check_password(password, db_password) do
-    if password == db_password do
-      true
-    else
-      false
-    end
-  end
-
   defp add_avatar_to_params(conn, params) do
     params = Map.put(params, "avatar", "")
 

--- a/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/dashboard_controller.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/dashboard_controller.ex
@@ -76,6 +76,8 @@ defmodule AcqdatApiWeb.DashboardManagement.DashboardController do
                    String.to_integer(Guardian.Plug.current_resource(conn))
                  ) do
               {:ok, _} ->
+                Dashboard.update(dashboard, %{opened_on: DateTime.utc_now()})
+
                 conn
                 |> put_status(200)
                 |> render("show.json", %{dashboard: dashboard})

--- a/apps/acqdat_api/lib/acqdat_api_web/router.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/router.ex
@@ -33,7 +33,7 @@ defmodule AcqdatApiWeb.Router do
 
     get(
       "/dashboards/:dashboard_uuid/verify",
-      DashboardManagement.DashboardController,
+      DashboardManagement.DashboardExportController,
       :exported_dashboard
     )
 

--- a/apps/acqdat_api/lib/acqdat_api_web/views/dashboard_management/dashboard_view.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/views/dashboard_management/dashboard_view.ex
@@ -15,6 +15,7 @@ defmodule AcqdatApiWeb.DashboardManagement.DashboardView do
       slug: dashboard.slug,
       uuid: dashboard.uuid,
       archived: dashboard.archived,
+      opened_on: dashboard.opened_on,
       settings: render_one(dashboard.settings, DashboardView, "settings.json"),
       avatar: dashboard.avatar,
       panels: render_many(dashboard.panels, PanelView, "panel.json"),

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/dashboard.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/model/dashboard.ex
@@ -80,7 +80,7 @@ defmodule AcqdatCore.Model.DashboardManagement.Dashboard do
         where:
           dashboard.org_id == ^org_id and dashboard.archived == false and
             dashboard.id in ^dashboard_ids,
-        order_by: dashboard.id
+        order_by: [desc: dashboard.opened_on]
       )
 
     query |> Repo.paginate(page: page_number, page_size: page_size)

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/dashboard.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/dashboard.ex
@@ -27,6 +27,7 @@ defmodule AcqdatCore.DashboardManagement.Schema.Dashboard do
     field(:slug, :string, null: false)
     field(:avatar, :string)
     field(:archived, :boolean, default: false)
+    field(:opened_on, :utc_datetime)
 
     # associations
     belongs_to(:org, Organisation, on_replace: :delete)
@@ -40,7 +41,7 @@ defmodule AcqdatCore.DashboardManagement.Schema.Dashboard do
   end
 
   @required_params ~w(uuid slug name org_id)a
-  @optional_params ~w(description avatar archived)a
+  @optional_params ~w(description avatar archived opened_on)a
   @permitted @optional_params ++ @required_params
 
   def changeset(%__MODULE__{} = dashboard, params) do

--- a/apps/acqdat_core/priv/repo/mads_apps.csv
+++ b/apps/acqdat_core/priv/repo/mads_apps.csv
@@ -10,7 +10,6 @@ Report Wizard,Make/automate drag-and-drop reports,Productivity,Datakrew,https://
 Alerts,Set alerts triggered by time or event,Productivity,Datakrew,https://datakrew.com,0,1,Datakrew,mads-alerts-reminders
 Madsbook,"Socialise with people, assets & processes",Productivity,Datakrew,https://datakrew.com,0,1,Datakrew,mads-book
 AR/VR Simulator,Enter into a VR experience of real assets,Productivity,Datakrew,https://datakrew.com,0,1,Datakrew,mads-vr-simulator
-Tenant Manager,"App to on-board tenants, allocate apps as per project needs and requirements",Management,Datakrew,https://datakrew.com,0,1,Datakrew,mads-tenant-manager
 File Manager,"Store and share data, dashboards, reports",Management,Datakrew,https://datakrew.com,0,1,Datakrew,mads-file-manager
 IoT Manager,Control IoT firmware and connectivity,Management,Datakrew,https://datakrew.com,0,1,Datakrew,mads-iot-manager
 Role Manager,Assign roles to users for access control,Management,Datakrew,https://datakrew.com,0,1,Datakrew,mads-role-manager

--- a/apps/acqdat_core/priv/repo/migrations/20210130070711_add_dashboard_opened_by.exs
+++ b/apps/acqdat_core/priv/repo/migrations/20210130070711_add_dashboard_opened_by.exs
@@ -1,0 +1,9 @@
+defmodule AcqdatCore.Repo.Migrations.AddDashboardOpenedBy do
+  use Ecto.Migration
+
+  def change do
+    alter table("acqdat_dashboard") do
+      add(:opened_on, :utc_datetime)
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -73,7 +73,7 @@ defmodule AcqdatUmbrella.MixProject do
       {:gen_retry, "~> 1.2.0"},
 
       # testing
-      {:excoveralls, "~> 0.10", only: :test},
+      {:excoveralls, "~> 0.10", only: :test}
     ]
   end
 


### PR DESCRIPTION
Since the role manager requires user id and exported dashboard doesn't provide us with one hence the code is shifted to dashboard export controller and the api access to these endpoints are open and doesn't come under role manager anymore.