### PR TITLE
[DashBoard Widgets]Fixes of widget settings + dashboard settings fixes

### DIFF
--- a/apps/acqdat_api/lib/acqdat_api_web/views/dashboard_management/dashboard_view.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/views/dashboard_management/dashboard_view.ex
@@ -68,7 +68,8 @@ defmodule AcqdatApiWeb.DashboardManagement.DashboardView do
       sidebar_color: settings.sidebar_color,
       thumbnail_url: settings.thumbnail_url,
       panels_order: settings.panels_order,
-      timezone: settings.timezone
+      timezone: settings.timezone,
+      selected_panel_color: settings.selected_panel_color
     }
   end
 end

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/dashboard.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/dashboard.ex
@@ -101,7 +101,7 @@ defmodule AcqdatCore.DashboardManagement.Schema.Dashboard.Settings do
     field(:thumbnail_url, :string)
     field(:timezone, :string)
     field(:panels_order, :map)
-    field(:selected_panel_color, :string)
+    field(:selected_panel_color, :string, default: "#FFFFFF")
   end
 
   @permitted ~w(background_color sidebar_color client_name thumbnail_url panels_order timezone selected_panel_color)a

--- a/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/dashboard.ex
+++ b/apps/acqdat_core/lib/acqdat_core/dashboard_management/schema/dashboard.ex
@@ -101,9 +101,10 @@ defmodule AcqdatCore.DashboardManagement.Schema.Dashboard.Settings do
     field(:thumbnail_url, :string)
     field(:timezone, :string)
     field(:panels_order, :map)
+    field(:selected_panel_color, :string)
   end
 
-  @permitted ~w(background_color sidebar_color client_name thumbnail_url panels_order timezone)a
+  @permitted ~w(background_color sidebar_color client_name thumbnail_url panels_order timezone selected_panel_color)a
 
   def changeset(%__MODULE__{} = settings, params) do
     settings |> cast(params, @permitted)

--- a/apps/acqdat_core/lib/acqdat_core/widgets/schema/vendors/custom_cards.ex
+++ b/apps/acqdat_core/lib/acqdat_core/widgets/schema/vendors/custom_cards.ex
@@ -69,6 +69,20 @@ defmodule AcqdatCore.Widgets.Schema.Vendors.CustomCards do
                 fontColor: %{data_type: :color, default_value: "#ffffff", user_controlled: true}
               }
             },
+            subtitle: %{
+              data_type: :object,
+              user_controlled: false,
+              properties: %{
+                text: %{data_type: :string, default_value: "", user_controlled: true},
+                align: %{
+                  data_type: :select,
+                  default_value: ["left", "right", "center", "top", "bottom"],
+                  user_controlled: true
+                },
+                fontSize: %{data_type: :integer, default_value: 12, user_controlled: true},
+                fontColor: %{data_type: :color, default_value: "#ffffff", user_controlled: true}
+              }
+            },
             series: %{
               data_type: :list,
               user_defined: false,

--- a/apps/acqdat_core/lib/acqdat_core/widgets/schema/vendors/custom_cards.ex
+++ b/apps/acqdat_core/lib/acqdat_core/widgets/schema/vendors/custom_cards.ex
@@ -16,7 +16,7 @@ defmodule AcqdatCore.Widgets.Schema.Vendors.CustomCards do
                   default_value: "#ffffff",
                   user_controlled: true
                 },
-                font: %{data_type: :string, default_value: "#ffffff", user_controlled: true}
+                fontColor: %{data_type: :color, default_value: "#ffffff", user_controlled: true}
               }
             },
             title: %{
@@ -24,7 +24,11 @@ defmodule AcqdatCore.Widgets.Schema.Vendors.CustomCards do
               user_controlled: false,
               properties: %{
                 text: %{data_type: :string, default_value: "", user_controlled: true},
-                align: %{data_type: :string, default_value: "center", user_controlled: true}
+                align: %{
+                  data_type: :select,
+                  default_value: ["left", "right", "center", "top", "bottom"],
+                  user_controlled: true
+                }
               }
             },
             unit: %{
@@ -32,7 +36,11 @@ defmodule AcqdatCore.Widgets.Schema.Vendors.CustomCards do
               user_controlled: false,
               properties: %{
                 text: %{data_type: :string, default_value: "", user_controlled: true},
-                align: %{data_type: :string, default_value: "center", user_controlled: true}
+                align: %{
+                  data_type: :select,
+                  default_value: ["left", "right", "center", "top", "bottom"],
+                  user_controlled: true
+                }
               }
             },
             icon: %{
@@ -40,7 +48,11 @@ defmodule AcqdatCore.Widgets.Schema.Vendors.CustomCards do
               user_controlled: false,
               properties: %{
                 text: %{data_type: :string, default_value: "", user_controlled: true},
-                align: %{data_type: :string, default_value: "center", user_controlled: true}
+                align: %{
+                  data_type: :select,
+                  default_value: ["left", "right", "center", "top", "bottom"],
+                  user_controlled: true
+                }
               }
             },
             description: %{
@@ -48,7 +60,13 @@ defmodule AcqdatCore.Widgets.Schema.Vendors.CustomCards do
               user_controlled: false,
               properties: %{
                 text: %{data_type: :string, default_value: "", user_controlled: true},
-                align: %{data_type: :string, default_value: "center", user_controlled: true}
+                align: %{
+                  data_type: :select,
+                  default_value: ["left", "right", "center", "top", "bottom"],
+                  user_controlled: true
+                },
+                fontSize: %{data_type: :integer, default_value: 14, user_controlled: true},
+                fontColor: %{data_type: :color, default_value: "#ffffff", user_controlled: true}
               }
             },
             series: %{

--- a/apps/acqdat_core/lib/acqdat_core/widgets/schema/vendors/highcharts.ex
+++ b/apps/acqdat_core/lib/acqdat_core/widgets/schema/vendors/highcharts.ex
@@ -38,7 +38,11 @@ defmodule AcqdatCore.Widgets.Schema.Vendors.HighCharts do
               user_controlled: false,
               properties: %{
                 text: %{data_type: :string, default_value: "", user_controlled: true},
-                align: %{data_type: :string, default_value: "left", user_controlled: true}
+                align: %{
+                  data_type: :select,
+                  default_value: ["left", "right", "center", "top", "bottom"],
+                  user_controlled: true
+                }
               }
             },
             color_axis: %{
@@ -70,7 +74,11 @@ defmodule AcqdatCore.Widgets.Schema.Vendors.HighCharts do
               properties: %{
                 enabled: %{data_type: :boolean, default_value: false, user_controlled: false},
                 layout: %{data_type: :string, default_value: "right", user_controlled: true},
-                align: %{data_type: :string, default_value: "right", user_controlled: true},
+                align: %{
+                  data_type: :select,
+                  default_value: ["right", "left", "center", "top", "bottom"],
+                  user_controlled: true
+                },
                 verticalAlign: %{
                   data_type: :string,
                   default_value: "middle",
@@ -172,7 +180,11 @@ defmodule AcqdatCore.Widgets.Schema.Vendors.HighCharts do
               properties: %{
                 text: %{data_type: :string, default_value: "", user_controlled: true},
                 style: %{data_type: :object, default_value: %{}, user_controlled: false},
-                align: %{data_type: :string, default_value: "center", user_controlled: true}
+                align: %{
+                  data_type: :select,
+                  default_value: ["center", "right", "left", "top", "bottom"],
+                  user_controlled: true
+                }
               }
             },
             time: %{
@@ -189,7 +201,11 @@ defmodule AcqdatCore.Widgets.Schema.Vendors.HighCharts do
               properties: %{
                 text: %{data_type: :string, default_value: "", user_controlled: true},
                 style: %{data_type: :object, default_value: %{}, user_controlled: false},
-                align: %{data_type: :string, default_value: "center", user_controlled: true}
+                align: %{
+                  data_type: :select,
+                  default_value: ["center", "right", "left", "top", "bottom"],
+                  user_controlled: true
+                }
               }
             },
             tooltip: %{

--- a/apps/acqdat_core/lib/acqdat_core/widgets/schema/vendors/highcharts.ex
+++ b/apps/acqdat_core/lib/acqdat_core/widgets/schema/vendors/highcharts.ex
@@ -314,6 +314,11 @@ defmodule AcqdatCore.Widgets.Schema.Vendors.HighCharts do
                       user_controlled: false
                     }
                   }
+                },
+                stops: %{
+                  data_type: :list,
+                  user_controlled: true,
+                  properties: %{}
                 }
               }
             },

--- a/apps/acqdat_core/priv/repo/seed/widgets/dynamic_card.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/dynamic_card.ex
@@ -10,11 +10,11 @@ defmodule AcqdatCore.Seed.Widgets.DynamicCard do
   @custom_card_key_widget_settings %{
     card: %{
       visual: %{
-        card: [type: %{value: "dynamic card"}, backgroundColor: %{}, font: %{}],
+        card: [type: %{value: "dynamic card"}, backgroundColor: %{}, fontColor: %{}],
         title: [text: %{}, align: %{}],
         unit: [text: %{}, align: %{}],
         icon: [text: %{}, align: %{}],
-        description: [text: %{}, align: %{}]
+        description: [text: %{}, fontSize: %{}, fontColor: %{}, align: %{}]
       },
       data: %{
         series: %{

--- a/apps/acqdat_core/priv/repo/seed/widgets/dynamic_card.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/dynamic_card.ex
@@ -14,7 +14,8 @@ defmodule AcqdatCore.Seed.Widgets.DynamicCard do
         title: [text: %{}, align: %{}],
         unit: [text: %{}, align: %{}],
         icon: [text: %{}, align: %{}],
-        description: [text: %{}, fontSize: %{}, fontColor: %{}, align: %{}]
+        description: [text: %{}, fontSize: %{}, fontColor: %{}, align: %{}],
+        subtitle: [text: %{}, fontSize: %{}, fontColor: %{}, align: %{}]
       },
       data: %{
         series: %{

--- a/apps/acqdat_core/priv/repo/seed/widgets/image_card.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/image_card.ex
@@ -10,9 +10,10 @@ defmodule AcqdatCore.Seed.Widgets.ImageCard do
   @custom_card_key_widget_settings %{
     card: %{
       visual: %{
-        card: [type: %{value: "image card"}, backgroundColor: %{}, font: %{}],
+        card: [type: %{value: "image card"}, backgroundColor: %{}, fontColor: %{}],
         title: [text: %{}, align: %{}],
-        icon: [text: %{}, align: %{}]
+        icon: [text: %{}, align: %{}],
+        description: [text: %{}, fontSize: %{}, fontColor: %{}, align: %{}]
       }
     }
   }

--- a/apps/acqdat_core/priv/repo/seed/widgets/image_card.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/image_card.ex
@@ -13,7 +13,8 @@ defmodule AcqdatCore.Seed.Widgets.ImageCard do
         card: [type: %{value: "image card"}, backgroundColor: %{}, fontColor: %{}],
         title: [text: %{}, align: %{}],
         icon: [text: %{}, align: %{}],
-        description: [text: %{}, fontSize: %{}, fontColor: %{}, align: %{}]
+        description: [text: %{}, fontSize: %{}, fontColor: %{}, align: %{}],
+        subtitle: [text: %{}, fontSize: %{}, fontColor: %{}, align: %{}]
       }
     }
   }

--- a/apps/acqdat_core/priv/repo/seed/widgets/solid_gauge.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/solid_gauge.ex
@@ -13,7 +13,14 @@ defmodule AcqdatCore.Seed.Widgets.SolidGauge do
         chart: [type: %{value: "solidgauge"}, backgroundColor: %{}, plotBackgroundColor: %{}],
         title: [text: %{}, align: %{}],
         yAxis: [title: [text: %{},  y: %{data_type: :integer, value: -70, properties: %{}}], min: %{data_type: :integer, value: 0, properties: %{}},
-                max: %{data_type: :integer, value: 200, properties: %{}}],
+                max: %{data_type: :integer, value: 200, properties: %{}},
+                stops: %{
+                  data_type: :list,
+                  value: [[0.1, "#55BF3B"], # green
+                          [0.5, "#DDDF0D"], #yellow
+                          [0.9, "#DF5353"]], #red
+                  properties: %{}
+                }],
         credits: [enabled: %{value: false}],
         pane: [startAngle: %{data_type: :integer, value: -90, properties: %{}},
                endAngle: %{data_type: :integer, value: 90, properties: %{}},
@@ -58,7 +65,11 @@ defmodule AcqdatCore.Seed.Widgets.SolidGauge do
             y: -70,
           },
           min: 0,
-          max: 5
+          max: 5,
+          stops: [[0.1, "#55BF3B"],
+                  [0.5, "#DDDF0D"],
+                  [0.9, "#DF5353"]
+          ]
         },
         pane: %{
         center: ["50%", "85%"],

--- a/apps/acqdat_core/priv/repo/seed/widgets/static_card.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/static_card.ex
@@ -12,7 +12,8 @@ defmodule AcqdatCore.Seed.Widgets.StaticCard do
       visual: %{
         card: [type: %{value: "static card"}, backgroundColor: %{}, fontColor: %{}],
         title: [text: %{}, align: %{}],
-        description: [text: %{}, fontSize: %{}, fontColor: %{}, align: %{}]
+        description: [text: %{}, fontSize: %{}, fontColor: %{}, align: %{}],
+        subtitle: [text: %{}, fontSize: %{}, fontColor: %{}, align: %{}]
       }
     }
   }

--- a/apps/acqdat_core/priv/repo/seed/widgets/static_card.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/static_card.ex
@@ -10,9 +10,9 @@ defmodule AcqdatCore.Seed.Widgets.StaticCard do
   @custom_card_key_widget_settings %{
     card: %{
       visual: %{
-        card: [type: %{value: "static card"}, backgroundColor: %{}, font: %{}],
+        card: [type: %{value: "static card"}, backgroundColor: %{}, fontColor: %{}],
         title: [text: %{}, align: %{}],
-        description: [text: %{}, align: %{}]
+        description: [text: %{}, fontSize: %{}, fontColor: %{}, align: %{}]
       }
     }
   }


### PR DESCRIPTION
**Deployment Dependency**

- Need to re-run mix task, `AcqdatCore.Seed.Widget.seed()`

**Changes**

- added selected_panel_color settings to dashboard whose default value is "#FFFFFF"
- updated highchart and custom_card vendors to accept `align` attribute as select with following values: ["left", "right", "center", "top", "bottom"]
- updated static, dynamic and image card widget skeleton: font to fontColor and its type + background settings + align
- Added Stops(Y-Axis)[List] Configuration On Solid Gauge Type Widget