### PR TITLE
Update widgets seed settings

### DIFF
--- a/apps/acqdat_core/lib/acqdat_core/widgets/schema/widget.ex
+++ b/apps/acqdat_core/lib/acqdat_core/widgets/schema/widget.ex
@@ -50,7 +50,7 @@ defmodule AcqdatCore.Widgets.Schema.Widget do
     field(:classification, :string, default: "timeseries")
 
     # embedded associations
-    embeds_many(:visual_settings, VisualSettings)
+    embeds_many(:visual_settings, VisualSettings, on_replace: :delete)
     embeds_many(:data_settings, DataSettings)
 
     # associations
@@ -110,7 +110,7 @@ defmodule AcqdatCore.Widgets.Schema.Widget.VisualSettings do
     field(:source, :map)
     field(:value, :map)
     field(:user_controlled, :boolean, default: false)
-    embeds_many(:properties, VisualSettings)
+    embeds_many(:properties, VisualSettings, on_replace: :delete)
   end
 
   @permitted ~w(key data_type source value user_controlled)a

--- a/apps/acqdat_core/lib/acqdat_core/widgets/schema/widget.ex
+++ b/apps/acqdat_core/lib/acqdat_core/widgets/schema/widget.ex
@@ -84,6 +84,10 @@ defmodule AcqdatCore.Widgets.Schema.Widget do
   def update_changeset(%__MODULE__{} = widget, params) do
     widget
     |> cast(params, @permitted)
+    |> cast_embed(:visual_settings, with: &VisualSettings.changeset/2)
+    |> cast_embed(:data_settings, with: &DataSettings.changeset/2)
+    |> validate_required(@required)
+    |> validate_inclusion(:classification, @classifications)
   end
 end
 

--- a/apps/acqdat_core/priv/repo/seed/helpers/widget_helpers.ex
+++ b/apps/acqdat_core/priv/repo/seed/helpers/widget_helpers.ex
@@ -165,11 +165,10 @@ defmodule AcqdatCore.Seed.Helpers.WidgetHelpers do
     end)
   end
 
-
   def set_mapped_keys_from_vendor(key, value, metadata) when is_tuple(value) do
-    %VisualSettings{
-      key: key,
-      data_type: metadata.data_type,
+    %{
+      key: to_string(key),
+      data_type: to_string(metadata.data_type),
       user_controlled: metadata.user_controlled,
       value: set_default_or_given_value(key, value, metadata),
       source: %{},
@@ -181,9 +180,9 @@ defmodule AcqdatCore.Seed.Helpers.WidgetHelpers do
   end
 
   def set_mapped_keys_from_vendor(key, value, metadata) when is_list(value) do
-    %VisualSettings{
-      key: key,
-      data_type: metadata.data_type,
+    %{
+      key: to_string(key),
+      data_type: to_string(metadata.data_type),
       user_controlled: metadata.user_controlled,
       value: set_default_or_given_value(key, value, metadata),
       source: %{},
@@ -195,13 +194,13 @@ defmodule AcqdatCore.Seed.Helpers.WidgetHelpers do
   end
 
   def set_mapped_keys_from_vendor(key, value, metadata) when is_map(value) do
-    %VisualSettings{
-      key: key,
-      data_type: metadata.data_type,
+    %{
+      key: to_string(key),
+      data_type: to_string(metadata.data_type),
       user_controlled: metadata.user_controlled,
       source: %{},
       value: set_default_or_given_value(key, value, metadata),
-      properties: properties_parsing(value, metadata)
+      properties: mapped_properties_parsing(value, metadata)
     }
   end
 

--- a/apps/acqdat_core/priv/repo/seed/helpers/widget_helpers.ex
+++ b/apps/acqdat_core/priv/repo/seed/helpers/widget_helpers.ex
@@ -153,4 +153,68 @@ defmodule AcqdatCore.Seed.Helpers.WidgetHelpers do
     {:ok, widget_type} = Repo.insert(changeset)
     widget_type
   end
+
+  ############### changes done to handle update ######################
+  # The above functions create schemas/structs which are good for insert however
+  # update only takes map as input the below functions does the same work
+  # however they return maps instead of structs.
+
+  def do_update_settings(%{visual: settings}, :visual, vendor_struct) do
+    Enum.map(settings, fn {key, value} ->
+      set_mapped_keys_from_vendor(key, value, Map.get(vendor_struct, key))
+    end)
+  end
+
+
+  def set_mapped_keys_from_vendor(key, value, metadata) when is_tuple(value) do
+    %VisualSettings{
+      key: key,
+      data_type: metadata.data_type,
+      user_controlled: metadata.user_controlled,
+      value: set_default_or_given_value(key, value, metadata),
+      source: %{},
+      properties: Enum.map(value,
+        fn {child_key, child_value} ->
+          set_mapped_keys_from_vendor(child_key, child_value, metadata.properties[child_key])
+      end)
+    }
+  end
+
+  def set_mapped_keys_from_vendor(key, value, metadata) when is_list(value) do
+    %VisualSettings{
+      key: key,
+      data_type: metadata.data_type,
+      user_controlled: metadata.user_controlled,
+      value: set_default_or_given_value(key, value, metadata),
+      source: %{},
+      properties: Enum.map(value,
+        fn {child_key, child_value} ->
+          set_mapped_keys_from_vendor(child_key, child_value, metadata.properties[child_key])
+      end)
+    }
+  end
+
+  def set_mapped_keys_from_vendor(key, value, metadata) when is_map(value) do
+    %VisualSettings{
+      key: key,
+      data_type: metadata.data_type,
+      user_controlled: metadata.user_controlled,
+      source: %{},
+      value: set_default_or_given_value(key, value, metadata),
+      properties: properties_parsing(value, metadata)
+    }
+  end
+
+  def mapped_properties_parsing(prop, metadata) do
+    if Map.has_key?(prop, :properties) do
+      Enum.map(prop.properties,
+        fn {child_key, child_value} ->
+          set_mapped_keys_from_vendor(child_key, child_value, metadata.properties[child_key])
+      end)
+    else
+      []
+    end
+  end
+
+
 end

--- a/apps/acqdat_core/priv/repo/seed/helpers/widget_update.ex
+++ b/apps/acqdat_core/priv/repo/seed/helpers/widget_update.ex
@@ -1,0 +1,31 @@
+defmodule AcqdatCore.Seed.Helpers.HighchartsUpdateHelpers do
+
+  defmacro __using__(_) do
+    quote do
+      Module.register_attribute(__MODULE__, :highchart_key_widget_settings, persist: true)
+      @before_compile unquote(__MODULE__)
+    end
+  end
+
+
+  defmacro __before_compile__(_env) do
+    module = __CALLER__.module
+    Module.get_attribute(module, :highchart_key_widget_settings)
+
+    quote do
+      alias AcqdatCore.Repo
+      alias AcqdatCore.Seed.Helpers.WidgetHelpers
+      alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
+      alias AcqdatCore.Widgets.Schema.Vendors.HighCharts
+
+      def update_visual_settings(label, key) do
+        widget = Repo.get_by(WidgetSchema, %{label: label})
+        widget_settings = @highchart_key_widget_settings[key]
+        visual_settings = WidgetHelpers.do_settings(widget_settings, :visual, %HighCharts{})
+        changeset = WidgetSchema.update_changeset(widget, %{visual_settings: visual_settings})
+        Repo.update!(changeset)
+      end
+    end
+  end
+
+end

--- a/apps/acqdat_core/priv/repo/seed/helpers/widget_update.ex
+++ b/apps/acqdat_core/priv/repo/seed/helpers/widget_update.ex
@@ -29,3 +29,34 @@ defmodule AcqdatCore.Seed.Helpers.HighchartsUpdateHelpers do
   end
 
 end
+
+
+defmodule AcqdatCore.Seed.Helpers.CustomCardUpdateHelpers do
+  defmacro __using__(_) do
+    quote do
+      Module.register_attribute(__MODULE__, :custom_card_key_widget_settings, persist: true)
+      @before_compile unquote(__MODULE__)
+    end
+  end
+
+
+  defmacro __before_compile__(_env) do
+    module = __CALLER__.module
+    Module.get_attribute(module, :custom_card_key_widget_settings)
+
+    quote do
+      alias AcqdatCore.Repo
+      alias AcqdatCore.Seed.Helpers.WidgetHelpers
+      alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
+      alias AcqdatCore.Widgets.Schema.Vendors.CustomCards
+
+      def update_visual_settings(label, key) do
+        widget = Repo.get_by(WidgetSchema, %{label: label})
+        widget_settings = @custom_card_key_widget_settings[key]
+        visual_settings = WidgetHelpers.do_update_settings(widget_settings, :visual, %CustomCards{})
+        changeset = WidgetSchema.update_changeset(widget, %{visual_settings: visual_settings})
+        Repo.update!(changeset)
+      end
+    end
+  end
+end

--- a/apps/acqdat_core/priv/repo/seed/helpers/widget_update.ex
+++ b/apps/acqdat_core/priv/repo/seed/helpers/widget_update.ex
@@ -21,7 +21,7 @@ defmodule AcqdatCore.Seed.Helpers.HighchartsUpdateHelpers do
       def update_visual_settings(label, key) do
         widget = Repo.get_by(WidgetSchema, %{label: label})
         widget_settings = @highchart_key_widget_settings[key]
-        visual_settings = WidgetHelpers.do_settings(widget_settings, :visual, %HighCharts{})
+        visual_settings = WidgetHelpers.do_update_settings(widget_settings, :visual, %HighCharts{})
         changeset = WidgetSchema.update_changeset(widget, %{visual_settings: visual_settings})
         Repo.update!(changeset)
       end

--- a/apps/acqdat_core/priv/repo/seed/widget.ex
+++ b/apps/acqdat_core/priv/repo/seed/widget.ex
@@ -5,6 +5,8 @@ defmodule AcqdatCore.Seed.Widget do
   alias AcqdatCore.Seed.Widgets.{Line, Area, Pie, Bar, LineTimeseries, AreaTimeseries, GaugeSeries, SolidGauge,
         StockSingleLine, DynamicCard, ImageCard, StaticCard, BasicColumn, StackedColumn}
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
+  alias AcqdatCore.Repo
+  alias AcqdatCore.Widgets.Schema.Widget
 
   def seed() do
     #Don't change the sequence it is important that widgets seeds this way.
@@ -23,5 +25,33 @@ defmodule AcqdatCore.Seed.Widget do
     BasicColumn.seed()
     StackedColumn.seed()
     WidgetHelpers.seed_in_elastic()
+  end
+
+  def update_visual_settings() do
+    highcharts = %{
+      "Area Range" => {AreaTimeseries, :area},
+      "area" => {Area, :area},
+      "bar" => {Bar, :bar},
+      "Basic Column" => {BasicColumn, :column},
+      "gauge" => {GaugeSeries, :gauge},
+      "Line Timeseries" => {LineTimeseries, :line},
+      "line" => {Line, :line},
+      "pie" => {Pie, :pie},
+      "solidgauge" => {SolidGauge, :solidgauge},
+      "Stacked Column" => {StackedColumn, :column},
+      "Stock Single line series" => {StockSingleLine, :line}
+    }
+
+    custom_widget = %{
+      "Dynamic Card" => {DynamicCard, :card},
+      "Image Card" => {ImageCard, :card},
+      "Static Card" => {StaticCard, :card}
+    }
+
+    Enum.each(highcharts, fn {label, value} ->
+      {module, widget_key} = value
+      module.update_visual_settings(label, widget_key)
+    end)
+
   end
 end

--- a/apps/acqdat_core/priv/repo/seed/widget.ex
+++ b/apps/acqdat_core/priv/repo/seed/widget.ex
@@ -28,7 +28,7 @@ defmodule AcqdatCore.Seed.Widget do
   end
 
   def update_visual_settings() do
-    highcharts = %{
+    charts = %{
       "Area Range" => {AreaTimeseries, :area},
       "area" => {Area, :area},
       "bar" => {Bar, :bar},
@@ -39,16 +39,13 @@ defmodule AcqdatCore.Seed.Widget do
       "pie" => {Pie, :pie},
       "solidgauge" => {SolidGauge, :solidgauge},
       "Stacked Column" => {StackedColumn, :column},
-      "Stock Single line series" => {StockSingleLine, :line}
-    }
-
-    custom_widget = %{
+      "Stock Single line series" => {StockSingleLine, :line},
       "Dynamic Card" => {DynamicCard, :card},
       "Image Card" => {ImageCard, :card},
       "Static Card" => {StaticCard, :card}
     }
 
-    Enum.each(highcharts, fn {label, value} ->
+    Enum.each(charts, fn {label, value} ->
       {module, widget_key} = value
       module.update_visual_settings(label, widget_key)
     end)

--- a/apps/acqdat_core/priv/repo/seed/widgets/area.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/area.ex
@@ -2,6 +2,7 @@ defmodule AcqdatCore.Seed.Widgets.Area do
   @moduledoc """
   Holds seeds for Area widgets.
   """
+  use AcqdatCore.Seed.Helpers.HighchartsUpdateHelpers
   alias AcqdatCore.Repo
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
@@ -119,4 +120,5 @@ defmodule AcqdatCore.Seed.Widgets.Area do
       default_values: data
     }
   end
+
 end

--- a/apps/acqdat_core/priv/repo/seed/widgets/area_timeseries.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/area_timeseries.ex
@@ -2,6 +2,7 @@ defmodule AcqdatCore.Seed.Widgets.AreaTimeseries do
   @moduledoc """
   Holds seeds for Area widgets.
   """
+  use AcqdatCore.Seed.Helpers.HighchartsUpdateHelpers
   alias AcqdatCore.Repo
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
@@ -120,4 +121,5 @@ defmodule AcqdatCore.Seed.Widgets.AreaTimeseries do
       default_values: data
     }
   end
+
 end

--- a/apps/acqdat_core/priv/repo/seed/widgets/bar.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/bar.ex
@@ -2,6 +2,7 @@ defmodule AcqdatCore.Seed.Widgets.Bar do
   @moduledoc """
   Holds seeds for Bar widgets.
   """
+  use AcqdatCore.Seed.Helpers.HighchartsUpdateHelpers
   alias AcqdatCore.Repo
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
@@ -109,4 +110,5 @@ defmodule AcqdatCore.Seed.Widgets.Bar do
       default_values: data
     }
   end
+
 end

--- a/apps/acqdat_core/priv/repo/seed/widgets/basic_column.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/basic_column.ex
@@ -2,6 +2,7 @@ defmodule AcqdatCore.Seed.Widgets.BasicColumn do
   @moduledoc """
   Holds seeds for Basic Column widgets.
   """
+  use AcqdatCore.Seed.Helpers.HighchartsUpdateHelpers
   alias AcqdatCore.Repo
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
@@ -38,6 +39,7 @@ defmodule AcqdatCore.Seed.Widgets.BasicColumn do
       }
     }
   }
+
 
   @high_chart_value_settings %{
     column: %{
@@ -100,4 +102,5 @@ defmodule AcqdatCore.Seed.Widgets.BasicColumn do
       default_values: data
     }
   end
+
 end

--- a/apps/acqdat_core/priv/repo/seed/widgets/dynamic_card.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/dynamic_card.ex
@@ -84,4 +84,5 @@ defmodule AcqdatCore.Seed.Widgets.DynamicCard do
       default_values: data
     }
   end
+
 end

--- a/apps/acqdat_core/priv/repo/seed/widgets/dynamic_card.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/dynamic_card.ex
@@ -2,6 +2,7 @@ defmodule AcqdatCore.Seed.Widgets.DynamicCard do
   @moduledoc """
   Holds seeds for DynamicCard widgets.
   """
+  use AcqdatCore.Seed.Helpers.CustomCardUpdateHelpers
   alias AcqdatCore.Repo
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema

--- a/apps/acqdat_core/priv/repo/seed/widgets/gauge_series.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/gauge_series.ex
@@ -2,6 +2,7 @@ defmodule AcqdatCore.Seed.Widgets.GaugeSeries do
   @moduledoc """
   Holds seeds for gauge-series widgets.
   """
+  use AcqdatCore.Seed.Helpers.HighchartsUpdateHelpers
   alias AcqdatCore.Repo
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
@@ -71,6 +72,7 @@ defmodule AcqdatCore.Seed.Widgets.GaugeSeries do
       }
     }
   }
+
 
   @high_chart_value_settings %{
     gauge: %{
@@ -153,4 +155,5 @@ defmodule AcqdatCore.Seed.Widgets.GaugeSeries do
       default_values: data
     }
   end
+
 end

--- a/apps/acqdat_core/priv/repo/seed/widgets/image_card.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/image_card.ex
@@ -2,6 +2,7 @@ defmodule AcqdatCore.Seed.Widgets.ImageCard do
   @moduledoc """
   Holds seeds for DynamicCard widgets.
   """
+  use AcqdatCore.Seed.Helpers.CustomCardUpdateHelpers
   alias AcqdatCore.Repo
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema

--- a/apps/acqdat_core/priv/repo/seed/widgets/line.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/line.ex
@@ -2,6 +2,7 @@ defmodule AcqdatCore.Seed.Widgets.Line do
   @moduledoc """
   Holds seeds for Line widgets.
   """
+  use AcqdatCore.Seed.Helpers.HighchartsUpdateHelpers
   alias AcqdatCore.Repo
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
@@ -111,4 +112,5 @@ defmodule AcqdatCore.Seed.Widgets.Line do
       default_values: data
     }
   end
+
 end

--- a/apps/acqdat_core/priv/repo/seed/widgets/line_timeseries.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/line_timeseries.ex
@@ -2,6 +2,7 @@ defmodule AcqdatCore.Seed.Widgets.LineTimeseries do
   @moduledoc """
   Holds seeds for Line widgets.
   """
+  use AcqdatCore.Seed.Helpers.HighchartsUpdateHelpers
   alias AcqdatCore.Repo
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
@@ -40,6 +41,7 @@ defmodule AcqdatCore.Seed.Widgets.LineTimeseries do
       }
     }
   }
+
 
   @high_chart_value_settings %{
     line: %{
@@ -112,4 +114,5 @@ defmodule AcqdatCore.Seed.Widgets.LineTimeseries do
       default_values: data
     }
   end
+
 end

--- a/apps/acqdat_core/priv/repo/seed/widgets/pie.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/pie.ex
@@ -2,6 +2,7 @@ defmodule AcqdatCore.Seed.Widgets.Pie do
   @moduledoc """
   Holds seeds for Pie widgets.
   """
+  use AcqdatCore.Seed.Helpers.HighchartsUpdateHelpers
   alias AcqdatCore.Repo
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
@@ -96,4 +97,5 @@ defmodule AcqdatCore.Seed.Widgets.Pie do
       default_values: data
     }
   end
+
 end

--- a/apps/acqdat_core/priv/repo/seed/widgets/solid_gauge.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/solid_gauge.ex
@@ -2,6 +2,7 @@ defmodule AcqdatCore.Seed.Widgets.SolidGauge do
   @moduledoc """
   Holds seeds for gauge-series widgets.
   """
+  use AcqdatCore.Seed.Helpers.HighchartsUpdateHelpers
   alias AcqdatCore.Repo
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
@@ -55,6 +56,7 @@ defmodule AcqdatCore.Seed.Widgets.SolidGauge do
       }
     }
   }
+
 
   @high_chart_value_settings %{
     solidgauge: %{
@@ -126,4 +128,5 @@ defmodule AcqdatCore.Seed.Widgets.SolidGauge do
       default_values: data
     }
   end
+
 end

--- a/apps/acqdat_core/priv/repo/seed/widgets/stacked_column.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/stacked_column.ex
@@ -2,6 +2,7 @@ defmodule AcqdatCore.Seed.Widgets.StackedColumn do
   @moduledoc """
   Holds seeds for Stacked Column widgets.
   """
+  use AcqdatCore.Seed.Helpers.HighchartsUpdateHelpers
   alias AcqdatCore.Repo
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
@@ -39,6 +40,7 @@ defmodule AcqdatCore.Seed.Widgets.StackedColumn do
       }
     }
   }
+
 
   @high_chart_value_settings %{
     column: %{
@@ -104,4 +106,5 @@ defmodule AcqdatCore.Seed.Widgets.StackedColumn do
       default_values: data
     }
   end
+
 end

--- a/apps/acqdat_core/priv/repo/seed/widgets/static_card.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/static_card.ex
@@ -2,6 +2,7 @@ defmodule AcqdatCore.Seed.Widgets.StaticCard do
   @moduledoc """
   Holds seeds for StaticCard widgets.
   """
+  use AcqdatCore.Seed.Helpers.CustomCardUpdateHelpers
   alias AcqdatCore.Repo
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema

--- a/apps/acqdat_core/priv/repo/seed/widgets/stock_single_line.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/stock_single_line.ex
@@ -2,6 +2,7 @@ defmodule AcqdatCore.Seed.Widgets.StockSingleLine do
   @moduledoc """
   Holds seeds for Line widgets.
   """
+  use AcqdatCore.Seed.Helpers.HighchartsUpdateHelpers
   alias AcqdatCore.Repo
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
@@ -92,4 +93,5 @@ defmodule AcqdatCore.Seed.Widgets.StockSingleLine do
       default_values: data
     }
   end
+
 end


### PR DESCRIPTION
# Why?
On changing vendor-related visual settings or settings for a widget there should be a way to seed the new settings.
