### PR TITLE
Enhancements/widget changes

### DIFF
--- a/apps/acqdat_api/lib/acqdat_api/dashboard_management/dashboard.ex
+++ b/apps/acqdat_api/lib/acqdat_api/dashboard_management/dashboard.ex
@@ -12,6 +12,14 @@ defmodule AcqdatApi.DashboardManagement.Dashboard do
 
   defdelegate recent_dashboards(data), to: DashboardModel
 
+  def get_panels_data(%{"id" => id, "filter_metadata" => filter_metadata}) do
+    PanelModel.get_with_widgets(id, %{"filter_metadata" => filter_metadata})
+  end
+
+  def get_panels_data(%{"id" => id}) do
+    PanelModel.get_with_widgets(id)
+  end
+
   def get_all(%{type: "archived"} = data) do
     DashboardModel.get_all_archived(data)
   end

--- a/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/dashboard_export_controller.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/controllers/dashboard_management/dashboard_export_controller.ex
@@ -2,7 +2,6 @@ defmodule AcqdatApiWeb.DashboardManagement.DashboardExportController do
   use AcqdatApiWeb, :controller
   import AcqdatApiWeb.Helpers
   alias AcqdatApi.DashboardExport.DashboardExport
-  alias AcqdatApi.DashboardManagement.Panel
   alias AcqdatApi.DashboardManagement.Dashboard
   import AcqdatApiWeb.Validators.DashboardExport.DashboardExport
 
@@ -104,12 +103,10 @@ defmodule AcqdatApiWeb.DashboardManagement.DashboardExportController do
     end
   end
 
-  def show(conn, %{"id" => id}) do
+  def show(conn, params) do
     case conn.status do
       nil ->
-        {id, _} = Integer.parse(id)
-
-        case Panel.get_with_widgets(id) do
+        case Dashboard.get_panels_data(params) do
           {:error, message} ->
             send_error(conn, 400, message)
 

--- a/apps/acqdat_api/lib/acqdat_api_web/controllers/widgets/widget_controller.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/controllers/widgets/widget_controller.ex
@@ -41,7 +41,7 @@ defmodule AcqdatApiWeb.Widgets.WidgetController do
     case conn.status do
       nil ->
         {:extract, {:ok, data}} = {:extract, extract_changeset_data(changeset)}
-        {:list, widgets} = {:list, WidgetModel.get_all_by_classification(data)}
+        {:list, widgets} = {:list, WidgetModel.get_all_by_classification_not_standard(data)}
 
         conn
         |> put_status(200)

--- a/apps/acqdat_api/lib/acqdat_api_web/router.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/router.ex
@@ -37,7 +37,7 @@ defmodule AcqdatApiWeb.Router do
       :exported_dashboard
     )
 
-    get(
+    post(
       "/details/:dashboard_uuid/panels/:id",
       DashboardManagement.DashboardExportController,
       :show

--- a/apps/acqdat_api/test/acqdat_api_web/controllers/dashboard_export/dashboard_export_controller_test.exs
+++ b/apps/acqdat_api/test/acqdat_api_web/controllers/dashboard_export/dashboard_export_controller_test.exs
@@ -231,7 +231,7 @@ defmodule AcqdatApiWeb.DashboardExport.DashboardExportControllerTest do
       dashboard: dashboard
     } do
       conn =
-        get(
+        post(
           conn,
           Routes.dashboard_export_path(conn, :show, dashboard.uuid, panel.id)
         )
@@ -253,7 +253,7 @@ defmodule AcqdatApiWeb.DashboardExport.DashboardExportControllerTest do
         |> put_req_header("authorization", "Bearer #{access_token}")
 
       conn =
-        get(
+        post(
           conn,
           Routes.dashboard_export_path(conn, :show, dashboard.uuid, -1)
         )
@@ -275,7 +275,7 @@ defmodule AcqdatApiWeb.DashboardExport.DashboardExportControllerTest do
         |> put_req_header("authorization", "Bearer #{access_token}")
 
       conn =
-        get(
+        post(
           conn,
           Routes.dashboard_export_path(conn, :show, dashboard.uuid, panel.id)
         )

--- a/apps/acqdat_api/test/acqdat_api_web/controllers/dashboard_export/dashboard_export_controller_test.exs
+++ b/apps/acqdat_api/test/acqdat_api_web/controllers/dashboard_export/dashboard_export_controller_test.exs
@@ -2,7 +2,8 @@ defmodule AcqdatApiWeb.DashboardExport.DashboardExportControllerTest do
   use ExUnit.Case, async: true
   use AcqdatApiWeb.ConnCase
   use AcqdatCore.DataCase
-  alias AcqdatCore.DashboardExport.Schema.DashboardExport
+  alias AcqdatCore.DashboardManagement.Schema.Dashboard
+  alias AcqdatCore.Model.DashboardExport.DashboardExport, as: DashboardExportModel
   alias AcqdatCore.Repo
   import AcqdatCore.Support.Factory
 
@@ -201,6 +202,90 @@ defmodule AcqdatApiWeb.DashboardExport.DashboardExportControllerTest do
       response = conn |> json_response(404)
 
       assert response == %{"errors" => %{"message" => "Resource Not Found"}}
+    end
+  end
+
+  describe "show/2" do
+    setup :setup_conn
+
+    setup do
+      panel = insert(:panel)
+
+      dashboard = Repo.get(Dashboard, panel.dashboard_id)
+
+      {:ok, private_dashboard_exp} =
+        DashboardExportModel.create(%{
+          token: UUID.uuid1(:hex),
+          is_secure: false,
+          dashboard_id: panel.dashboard_id,
+          dashboard_uuid: dashboard.uuid,
+          url: "url"
+        })
+
+      [panel: panel, dashboard: dashboard, private_dashboard_exp: private_dashboard_exp]
+    end
+
+    test "fails if invalid token in authorization header", %{
+      conn: conn,
+      panel: panel,
+      dashboard: dashboard
+    } do
+      conn =
+        get(
+          conn,
+          Routes.dashboard_export_path(conn, :show, dashboard.uuid, panel.id)
+        )
+
+      result = conn |> json_response(401)
+
+      assert result == %{"errors" => %{"message" => "Unauthorized link"}}
+    end
+
+    test "panel with invalid panel id", %{
+      conn: conn,
+      dashboard: dashboard,
+      private_dashboard_exp: private_dashboard_exp
+    } do
+      access_token = private_dashboard_exp.token
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{access_token}")
+
+      conn =
+        get(
+          conn,
+          Routes.dashboard_export_path(conn, :show, dashboard.uuid, -1)
+        )
+
+      result = conn |> json_response(404)
+      assert result == %{"errors" => %{"message" => "Resource Not Found"}}
+    end
+
+    test "panel with valid id", %{
+      conn: conn,
+      panel: panel,
+      dashboard: dashboard,
+      private_dashboard_exp: private_dashboard_exp
+    } do
+      access_token = private_dashboard_exp.token
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{access_token}")
+
+      conn =
+        get(
+          conn,
+          Routes.dashboard_export_path(conn, :show, dashboard.uuid, panel.id)
+        )
+
+      result = conn |> json_response(200)
+
+      refute is_nil(result)
+
+      assert Map.has_key?(result, "id")
+      assert Map.has_key?(result, "name")
     end
   end
 end

--- a/apps/acqdat_core/lib/acqdat_core/entity-management/domain/sensor_data.ex
+++ b/apps/acqdat_core/lib/acqdat_core/entity-management/domain/sensor_data.ex
@@ -44,6 +44,27 @@ defmodule AcqdatCore.Domain.EntityManagement.SensorData do
         grp_interval,
         group_interval_type
       )
+      when aggregator == "no" and is_binary(param_uuid) do
+    from(
+      data in subquery,
+      cross_join: c in fragment("unnest(?)", data.parameters),
+      where: fragment("?->>'uuid'=?", c, ^param_uuid),
+      order_by: [desc: data.inserted_timestamp],
+      limit: 1,
+      select: %{
+        x: fragment("EXTRACT(EPOCH FROM ?)*1000", data.inserted_timestamp),
+        y: fragment("?->>'value'", c)
+      }
+    )
+  end
+
+  def latest_group_by_date_query(
+        subquery,
+        param_uuid,
+        aggregator,
+        grp_interval,
+        group_interval_type
+      )
       when aggregator == "sum" and is_binary(param_uuid) do
     grp_int = grp_interval |> compute_grp_interval(group_interval_type)
 
@@ -62,6 +83,30 @@ defmodule AcqdatCore.Domain.EntityManagement.SensorData do
             data.inserted_timestamp
           ),
         y: fragment("sum(CAST(ROUND(CAST (?->>'value' AS NUMERIC), 2) AS FLOAT))", c)
+      }
+    )
+  end
+
+  def latest_group_by_date_query(
+        subquery,
+        param_uuids,
+        aggregator,
+        grp_interval,
+        group_interval_type,
+        limit_elem
+      )
+      when aggregator == "no" and is_list(param_uuids) do
+    from(
+      data in subquery,
+      cross_join: c in fragment("unnest(?)", data.parameters),
+      where: fragment("?->>'uuid'=?", c, ^param_uuids),
+      group_by: [data.sensor_id, data.inserted_timestamp],
+      order_by: [desc: data.inserted_timestamp],
+      limit: ^limit_elem,
+      select: %{
+        time: fragment("EXTRACT(EPOCH FROM ?)*1000", data.inserted_timestamp),
+        id: data.sensor_id,
+        value: fragment("?->>'value'", c)
       }
     )
   end
@@ -334,6 +379,20 @@ defmodule AcqdatCore.Domain.EntityManagement.SensorData do
           ),
         y: fragment("avg(CAST(ROUND(CAST (?->>'value' AS NUMERIC), 2) AS FLOAT))", c)
       }
+    )
+  end
+
+  def group_by_date_query(subquery, param_uuid, aggregator, grp_interval, group_interval_type)
+      when aggregator == "no" do
+    from(
+      data in subquery,
+      cross_join: c in fragment("unnest(?)", data.parameters),
+      where: fragment("?->>'uuid'=?", c, ^param_uuid),
+      order_by: [desc: data.inserted_timestamp],
+      select: [
+        fragment("EXTRACT(EPOCH FROM ?)*1000", data.inserted_timestamp),
+        fragment("?->>'value'", c)
+      ]
     )
   end
 

--- a/apps/acqdat_core/lib/acqdat_core/entity-management/domain/sensor_data.ex
+++ b/apps/acqdat_core/lib/acqdat_core/entity-management/domain/sensor_data.ex
@@ -49,7 +49,7 @@ defmodule AcqdatCore.Domain.EntityManagement.SensorData do
       data in subquery,
       cross_join: c in fragment("unnest(?)", data.parameters),
       where: fragment("?->>'uuid'=?", c, ^param_uuid),
-      order_by: [desc: data.inserted_timestamp],
+      order_by: [asc: data.inserted_timestamp],
       limit: 1,
       select: %{
         x: fragment("EXTRACT(EPOCH FROM ?)*1000", data.inserted_timestamp),
@@ -101,7 +101,7 @@ defmodule AcqdatCore.Domain.EntityManagement.SensorData do
       cross_join: c in fragment("unnest(?)", data.parameters),
       where: fragment("?->>'uuid'=?", c, ^param_uuids),
       group_by: [data.sensor_id, data.inserted_timestamp],
-      order_by: [desc: data.inserted_timestamp],
+      order_by: [asc: data.inserted_timestamp],
       limit: ^limit_elem,
       select: %{
         time: fragment("EXTRACT(EPOCH FROM ?)*1000", data.inserted_timestamp),
@@ -388,7 +388,7 @@ defmodule AcqdatCore.Domain.EntityManagement.SensorData do
       data in subquery,
       cross_join: c in fragment("unnest(?)", data.parameters),
       where: fragment("?->>'uuid'=?", c, ^param_uuid),
-      order_by: [desc: data.inserted_timestamp],
+      order_by: [asc: data.inserted_timestamp],
       select: [
         fragment("EXTRACT(EPOCH FROM ?)*1000", data.inserted_timestamp),
         fragment("CAST(ROUND(CAST (?->>'value' AS NUMERIC), 2) AS FLOAT)", c)

--- a/apps/acqdat_core/lib/acqdat_core/entity-management/domain/sensor_data.ex
+++ b/apps/acqdat_core/lib/acqdat_core/entity-management/domain/sensor_data.ex
@@ -53,7 +53,7 @@ defmodule AcqdatCore.Domain.EntityManagement.SensorData do
       limit: 1,
       select: %{
         x: fragment("EXTRACT(EPOCH FROM ?)*1000", data.inserted_timestamp),
-        y: fragment("?->>'value'", c)
+        y: fragment("CAST(ROUND(CAST (?->>'value' AS NUMERIC), 2) AS FLOAT)", c)
       }
     )
   end
@@ -106,7 +106,7 @@ defmodule AcqdatCore.Domain.EntityManagement.SensorData do
       select: %{
         time: fragment("EXTRACT(EPOCH FROM ?)*1000", data.inserted_timestamp),
         id: data.sensor_id,
-        value: fragment("?->>'value'", c)
+        value: fragment("CAST(ROUND(CAST (?->>'value' AS NUMERIC), 2) AS FLOAT)", c)
       }
     )
   end
@@ -391,7 +391,7 @@ defmodule AcqdatCore.Domain.EntityManagement.SensorData do
       order_by: [desc: data.inserted_timestamp],
       select: [
         fragment("EXTRACT(EPOCH FROM ?)*1000", data.inserted_timestamp),
-        fragment("?->>'value'", c)
+        fragment("CAST(ROUND(CAST (?->>'value' AS NUMERIC), 2) AS FLOAT)", c)
       ]
     )
   end

--- a/apps/acqdat_core/lib/acqdat_core/widgets/model/widget.ex
+++ b/apps/acqdat_core/lib/acqdat_core/widgets/model/widget.ex
@@ -11,7 +11,7 @@ defmodule AcqdatCore.Model.Widgets.Widget do
     Repo.insert(changeset)
   end
 
-  def get(id) when is_integer(id) do
+  def get(id) do
     case Repo.get(Widget, id) do
       nil ->
         {:error, "not found"}

--- a/apps/acqdat_core/lib/acqdat_core/widgets/schema/vendors/highcharts.ex
+++ b/apps/acqdat_core/lib/acqdat_core/widgets/schema/vendors/highcharts.ex
@@ -73,15 +73,19 @@ defmodule AcqdatCore.Widgets.Schema.Vendors.HighCharts do
               user_controlled: false,
               properties: %{
                 enabled: %{data_type: :boolean, default_value: false, user_controlled: false},
-                layout: %{data_type: :string, default_value: "right", user_controlled: true},
+                layout: %{
+                  data_type: :select,
+                  default_value: ["right", "center", "left", "top", "bottom"],
+                  user_controlled: true
+                },
                 align: %{
                   data_type: :select,
-                  default_value: ["right", "left", "center", "top", "bottom"],
+                  default_value: ["center", "left", "right", "top", "bottom"],
                   user_controlled: true
                 },
                 verticalAlign: %{
-                  data_type: :string,
-                  default_value: "middle",
+                  data_type: :select,
+                  default_value: ["bottom", "center", "left", "right", "top"],
                   user_controlled: true
                 }
               }

--- a/apps/acqdat_core/lib/acqdat_core/widgets/schema/vendors/highcharts.ex
+++ b/apps/acqdat_core/lib/acqdat_core/widgets/schema/vendors/highcharts.ex
@@ -482,11 +482,9 @@ defmodule AcqdatCore.Widgets.Schema.Vendors.HighCharts do
          %{classification: classification},
          filter_metadata
        )
-       when classification == "latest" do
+       when classification == "timseries" do
     Enum.reduce(series_data, [], fn series, acc_data ->
-      nil
-      metadata = fetch_latest_axes_spec_data(series.axes, filter_metadata)
-
+      metadata = fetch_axes_specific_data(series.axes, filter_metadata)
       acc_data ++ [%{name: series.name, color: series.color, data: metadata}]
     end)
   end
@@ -496,9 +494,11 @@ defmodule AcqdatCore.Widgets.Schema.Vendors.HighCharts do
          %{classification: classification},
          filter_metadata
        )
-       when classification != "latest" do
+       when classification != "timseries" do
     Enum.reduce(series_data, [], fn series, acc_data ->
-      metadata = fetch_axes_specific_data(series.axes, filter_metadata)
+      nil
+      metadata = fetch_latest_axes_spec_data(series.axes, filter_metadata)
+
       acc_data ++ [%{name: series.name, color: series.color, data: metadata}]
     end)
   end

--- a/apps/acqdat_core/lib/acqdat_core/widgets/schema/vendors/highcharts.ex
+++ b/apps/acqdat_core/lib/acqdat_core/widgets/schema/vendors/highcharts.ex
@@ -482,7 +482,7 @@ defmodule AcqdatCore.Widgets.Schema.Vendors.HighCharts do
          %{classification: classification},
          filter_metadata
        )
-       when classification == "timseries" do
+       when classification == "timeseries" do
     Enum.reduce(series_data, [], fn series, acc_data ->
       metadata = fetch_axes_specific_data(series.axes, filter_metadata)
       acc_data ++ [%{name: series.name, color: series.color, data: metadata}]
@@ -494,7 +494,7 @@ defmodule AcqdatCore.Widgets.Schema.Vendors.HighCharts do
          %{classification: classification},
          filter_metadata
        )
-       when classification != "timseries" do
+       when classification != "timeseries" do
     Enum.reduce(series_data, [], fn series, acc_data ->
       nil
       metadata = fetch_latest_axes_spec_data(series.axes, filter_metadata)
@@ -512,7 +512,7 @@ defmodule AcqdatCore.Widgets.Schema.Vendors.HighCharts do
 
   defp fetch_axes_specific_data(axes, filter_metadata) do
     Enum.reduce(axes, [], fn axis, acc ->
-      res = axis |> validate_data_source(filter_metadata, "timseries")
+      res = axis |> validate_data_source(filter_metadata, "timeseries")
       acc ++ (res || [])
     end)
   end
@@ -557,7 +557,7 @@ defmodule AcqdatCore.Widgets.Schema.Vendors.HighCharts do
          filter_metadata,
          type
        )
-       when entity_type == "sensor" and type == "timseries" do
+       when entity_type == "sensor" and type == "timeseries" do
     SensorData.get_all_by_parameters(entity_id, parameter, filter_metadata)
   end
 

--- a/apps/acqdat_core/lib/acqdat_core/widgets/schema/widget.ex
+++ b/apps/acqdat_core/lib/acqdat_core/widgets/schema/widget.ex
@@ -36,7 +36,7 @@ defmodule AcqdatCore.Widgets.Schema.Widget do
   `data_settings`: holds data related settings for a widget
   """
 
-  @classifications ~w(timeseries latest standard)s
+  @classifications ~w(timeseries latest standard cards gauge)s
   @type t :: %__MODULE__{}
 
   schema("acqdat_widgets") do

--- a/apps/acqdat_core/priv/repo/seed/widget.ex
+++ b/apps/acqdat_core/priv/repo/seed/widget.ex
@@ -3,7 +3,7 @@ defmodule AcqdatCore.Seed.Widget do
   Holds seeds for initial widgets.
   """
   alias AcqdatCore.Seed.Widgets.{Line, Area, Pie, Bar, LineTimeseries, AreaTimeseries, GaugeSeries, SolidGauge,
-        StockSingleLine, DynamicCard, ImageCard, StaticCard, BasicColumn, StackedColumn}
+        StockSingleLine, DynamicCard, ImageCard, StaticCard, BasicColumn, StackedColumn, StockColumn}
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Repo
   alias AcqdatCore.Widgets.Schema.Widget
@@ -25,6 +25,7 @@ defmodule AcqdatCore.Seed.Widget do
     StaticCard.seed()
     BasicColumn.seed()
     StackedColumn.seed()
+    StockColumn.seed()
     WidgetHelpers.seed_in_elastic()
   end
 

--- a/apps/acqdat_core/priv/repo/seed/widget.ex
+++ b/apps/acqdat_core/priv/repo/seed/widget.ex
@@ -7,6 +7,7 @@ defmodule AcqdatCore.Seed.Widget do
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Repo
   alias AcqdatCore.Widgets.Schema.Widget
+  alias AcqdatCore.Model.Widgets.Widget, as: WidgetModel
 
   def seed() do
     #Don't change the sequence it is important that widgets seeds this way.
@@ -25,6 +26,19 @@ defmodule AcqdatCore.Seed.Widget do
     BasicColumn.seed()
     StackedColumn.seed()
     WidgetHelpers.seed_in_elastic()
+  end
+
+  def update_classifications() do
+    Repo.transaction(fn ->
+      card_widgets = ["Image Card", "Static Card", "Dynamic Card"]
+      update_classifications_of_widgets(card_widgets, "cards")
+
+      gauge_widgets = ["solidgauge", "gauge"]
+      update_classifications_of_widgets(gauge_widgets, "gauge")
+
+      pie_widget = ["pie"]
+      update_classifications_of_widgets(pie_widget, "standard")
+    end)
   end
 
   def update_visual_settings() do
@@ -49,6 +63,16 @@ defmodule AcqdatCore.Seed.Widget do
       {module, widget_key} = value
       module.update_visual_settings(label, widget_key)
     end)
+  end
 
+  defp update_classifications_of_widgets(widgets, classification) do
+    Enum.each(widgets, fn name ->
+      case WidgetModel.get_by_label(name) do
+        {:ok, widget} ->
+          WidgetModel.update(widget, %{classification: classification})
+        _ ->
+          name
+      end
+    end)
   end
 end

--- a/apps/acqdat_core/priv/repo/seed/widget.ex
+++ b/apps/acqdat_core/priv/repo/seed/widget.ex
@@ -6,7 +6,6 @@ defmodule AcqdatCore.Seed.Widget do
         StockSingleLine, DynamicCard, ImageCard, StaticCard, BasicColumn, StackedColumn, StockColumn}
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Repo
-  alias AcqdatCore.Widgets.Schema.Widget
   alias AcqdatCore.Model.Widgets.Widget, as: WidgetModel
 
   def seed() do
@@ -57,7 +56,8 @@ defmodule AcqdatCore.Seed.Widget do
       "Stock Single line series" => {StockSingleLine, :line},
       "Dynamic Card" => {DynamicCard, :card},
       "Image Card" => {ImageCard, :card},
-      "Static Card" => {StaticCard, :card}
+      "Static Card" => {StaticCard, :card},
+      "Stock Column" => {StockColumn, :column}
     }
 
     Enum.each(charts, fn {label, value} ->

--- a/apps/acqdat_core/priv/repo/seed/widgets/area_timeseries.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/area_timeseries.ex
@@ -18,6 +18,7 @@ defmodule AcqdatCore.Seed.Widgets.AreaTimeseries do
         yAxis: [title: [text: %{}]],
         xAxis: [type: %{value: "datetime"}, title: [text: %{value: "Date"}]],
         credits: [enabled: %{value: false}],
+        legend: [enabled: %{value: true}]
       },
       data: %{
         series: %{

--- a/apps/acqdat_core/priv/repo/seed/widgets/line.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/line.ex
@@ -16,7 +16,7 @@ defmodule AcqdatCore.Seed.Widgets.Line do
         caption: [text: %{}, align: %{}],
         subtitle: [text: %{}, align: %{}],
         yAxis: [title: [text: %{}]],
-        credits: [enabled: %{value: false}],
+        credits: [enabled: %{value: false}]
       },
       data: %{
         series: %{

--- a/apps/acqdat_core/priv/repo/seed/widgets/line_timeseries.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/line_timeseries.ex
@@ -18,6 +18,7 @@ defmodule AcqdatCore.Seed.Widgets.LineTimeseries do
         yAxis: [title: [text: %{}]],
         xAxis: [type: %{value: "datetime"}, title: [text: %{value: "Date"}]],
         credits: [enabled: %{value: false}],
+        legend: [enabled: %{value: true}]
       },
       data: %{
         series: %{

--- a/apps/acqdat_core/priv/repo/seed/widgets/stock_column.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/stock_column.ex
@@ -1,0 +1,99 @@
+defmodule AcqdatCore.Seed.Widgets.StockColumn do
+  @moduledoc """
+  Holds seeds for Stock Column widgets.
+  """
+  use AcqdatCore.Seed.Helpers.HighchartsUpdateHelpers
+  alias AcqdatCore.Repo
+  alias AcqdatCore.Seed.Helpers.WidgetHelpers
+  alias AcqdatCore.Widgets.Schema.Widget, as: WidgetSchema
+  alias AcqdatCore.Widgets.Schema.Vendors.HighCharts
+
+  @highchart_key_widget_settings %{
+    column: %{
+      visual: %{
+        chart: [type: %{value: "column"}],
+        title: [text: %{}],
+        rangeSelector: [selected: %{value: 1}],
+        credits: [enabled: %{value: false}],
+        legend: [enabled: %{value: true}]
+      },
+      data: %{
+        series: %{
+          data_type: :object,
+          value: %{},
+          properties: %{
+            name: %{data_type: :string, value: %{}, properties: %{}},
+            multiple: %{data_type: :boolean, value: %{data: false}, properties: %{}}
+          }
+        },
+        axes: %{
+          data_type: :object,
+          value: %{},
+          properties: %{
+            multiple: %{data_type: :boolean, value: %{data: true}, properties: %{}},
+            x: %{data_type: :list, value: %{}, properties: %{}},
+            y: %{data_type: :list, value: %{}, properties: %{}}
+          }
+        }
+      }
+    }
+  }
+
+  @high_chart_value_settings %{
+    column: %{
+      visual_setting_values: %{
+        title: %{text: "AAPL Stock Price"},
+        rangeSelector: %{selected: 1},
+        legend: %{enabled: true}
+      },
+      data_settings_values: %{
+        series: [
+          %{
+            name: "AAPL",
+            data: [
+              %{x: 1533735000000, y: 207.25},
+              %{x: 1533821400000, y: 208.88},
+              %{x: 1533907800000, y: 207.53},
+              %{x: 1534167000000, y: 208.87},
+              %{x: 1534253400000, y: 209.75},
+              %{x: 1534339800000, y: 210.24},
+              %{x: 1534426200000, y: 213.32}
+            ]
+          }
+        ]
+      }
+    }
+  }
+
+  def seed() do
+    widget_type = WidgetHelpers.find_or_create_widget_type("HighCharts")
+    seed_widgets(widget_type)
+  end
+
+  def seed_widgets(widget_type) do
+    @highchart_key_widget_settings
+    |> Enum.map(fn {key, widget_settings} ->
+      set_widget_data(key, widget_settings, @high_chart_value_settings[key],
+        widget_type)
+    end)
+    |> Enum.each(fn data ->
+      Repo.insert!(data)
+    end)
+  end
+
+  def set_widget_data(_key, widget_settings, data, widget_type) do
+    %WidgetSchema{
+      label: "Stock Column",
+      properties: %{},
+      uuid: UUID.uuid1(:hex),
+      image_url: "https://www.highcharts.com/demo/images/samples/stock/demo/column/thumbnail.png",
+      category: ["stock_chart", "column"],
+      policies: %{},
+      widget_type_id: widget_type.id,
+      visual_settings: WidgetHelpers.do_settings(widget_settings, :visual, %HighCharts{}),
+      data_settings: WidgetHelpers.do_settings(widget_settings, :data, %HighCharts{}),
+      default_values: data
+    }
+  end
+
+end

--- a/apps/acqdat_core/priv/repo/seed/widgets/stock_single_line.ex
+++ b/apps/acqdat_core/priv/repo/seed/widgets/stock_single_line.ex
@@ -15,6 +15,7 @@ defmodule AcqdatCore.Seed.Widgets.StockSingleLine do
         title: [text: %{}],
         rangeSelector: [selected: %{value: 1}],
         credits: [enabled: %{value: false}],
+        legend: [enabled: %{value: true}]
       },
       data: %{
         series: %{

--- a/apps/acqdat_core/test/widgets/model/widget_test.exs
+++ b/apps/acqdat_core/test/widgets/model/widget_test.exs
@@ -1,0 +1,171 @@
+defmodule AcqdatCore.Model.Widgets.WidgetTest do
+  use ExUnit.Case, async: true
+  use AcqdatCore.DataCase
+
+  import AcqdatCore.Support.Factory
+
+  alias AcqdatCore.Model.Widgets.Widget
+
+  describe "get/1" do
+    test "returns a particular widget by id" do
+      widget = insert(:widget)
+
+      {:ok, result} = Widget.get(widget.id)
+      assert not is_nil(result)
+      assert result.id == widget.id
+    end
+
+    test "returns error not found, if widget is not present" do
+      {:error, result} = Widget.get(-1)
+      assert result == "not found"
+    end
+  end
+
+  describe "get_by_label/1" do
+    test "returns a particular widget by id" do
+      widget = insert(:widget)
+
+      {:ok, result} = Widget.get_by_label(widget.label)
+      assert not is_nil(result)
+      assert result.label == widget.label
+    end
+
+    test "returns error not found, if widget is not present" do
+      {:error, result} = Widget.get_by_label("demo dfr")
+      assert result == "not found"
+    end
+  end
+
+  describe "create/1" do
+    setup do
+      widget_type = insert(:widget_type)
+
+      [widget_type: widget_type]
+    end
+
+    test "creates a widget with valid supplied params", %{widget_type: widget_type} do
+      params = %{
+        label: "line widget",
+        widget_type_id: widget_type.id,
+        default_values: %{
+          "data_settings_values" => %{
+            "series" => []
+          },
+          "visual_setting_values" => %{
+            "rangeSelector" => %{
+              "selected" => 1
+            },
+            "title" => %{
+              "text" => "AAPL Stock Price"
+            }
+          }
+        }
+      }
+
+      assert {:ok, widget} = Widget.create(params)
+      assert widget.label == "line widget"
+    end
+
+    test "fails if widget_type_id is not present" do
+      params = %{
+        label: "line widget",
+        default_values: %{
+          "data_settings_values" => %{
+            "series" => []
+          },
+          "visual_setting_values" => %{
+            "rangeSelector" => %{
+              "selected" => 1
+            },
+            "title" => %{
+              "text" => "AAPL Stock Price"
+            }
+          }
+        }
+      }
+
+      assert {:error, changeset} = Widget.create(params)
+      assert %{widget_type_id: ["can't be blank"]} == errors_on(changeset)
+    end
+
+    test "fails if label is not present", %{widget_type: widget_type} do
+      params = %{
+        widget_type_id: widget_type.id,
+        default_values: %{
+          "data_settings_values" => %{
+            "series" => []
+          },
+          "visual_setting_values" => %{
+            "rangeSelector" => %{
+              "selected" => 1
+            },
+            "title" => %{
+              "text" => "AAPL Stock Price"
+            }
+          }
+        }
+      }
+
+      assert {:error, changeset} = Widget.create(params)
+      assert %{label: ["can't be blank"]} == errors_on(changeset)
+    end
+  end
+
+  describe "get_all_by_classification_not_standard/1" do
+    setup do
+      widget = insert(:widget)
+      gauge = insert(:widget, classification: "gauge")
+      standard = insert(:widget, classification: "standard")
+
+      [widget: widget, gauge: gauge, standard: standard]
+    end
+
+    test "should not list standard type classification", %{widget: _widget} do
+      grouped = Widget.get_all_by_classification_not_standard(%{})
+      res = Enum.map(grouped, fn x -> x.classification end)
+      assert Enum.sort(res) == ["gauge", "timeseries"]
+    end
+  end
+
+  describe "get_all_by_classification/1" do
+    setup do
+      widget = insert(:widget)
+      gauge = insert(:widget, classification: "gauge")
+      standard = insert(:widget, classification: "standard")
+
+      [widget: widget, gauge: gauge, standard: standard]
+    end
+
+    test "should not list standard type classification", %{widget: _widget} do
+      grouped = Widget.get_all_by_classification(%{})
+      res = Enum.map(grouped, fn x -> x.classification end)
+      assert Enum.sort(res) == ["gauge", "standard", "timeseries"]
+    end
+  end
+
+  describe "update/2" do
+    setup do
+      widget = insert(:widget)
+
+      [widget: widget]
+    end
+
+    test "updating widget name/params will name", %{widget: widget} do
+      assert {:ok, result} = Widget.update(widget, %{"label" => "updated widget name"})
+      assert result.label == "updated widget name"
+    end
+  end
+
+  describe "delete/1" do
+    setup do
+      widget = insert(:widget)
+
+      [widget: widget]
+    end
+
+    test "successfully delete widget", %{widget: widget} do
+      assert {:ok, result} = Widget.delete(widget)
+      assert result.id == widget.id
+    end
+  end
+end


### PR DESCRIPTION
**Changes**

- Changed widget filtered listing api, to not include standard in the grouping classification
- Changed Widget's Classifications as follows:
    1) Dynamic Card, Static Card, Image Card -> 'cards'
    2) solid gauge and gauge series -> 'gauge'
    3) pie -> 'standard'
- Added legend configuration to timeseries type widgets
- Added new highstock column chart of timeseries type classification
- Widget Add Latest Query For Gauge And Cards Type
- Add No Aggregation Filter Option Functionality To Panel/Dashboard
- Update Widget Seed Update_visual_settings Method To Include Stock Column Widget


Need to run following mix tasks after deployments
- **AcqdatCore.Seed.Widgets.StockColumn.seed()**
- **AcqdatCore.Seed.Widget.update_classifications()**