### PR TITLE
Allow error logging to db for timestamp errors

### DIFF
--- a/apps/acqdat_core/lib/acqdat_core/iot-manager/data_dump/worker.ex
+++ b/apps/acqdat_core/lib/acqdat_core/iot-manager/data_dump/worker.ex
@@ -43,7 +43,7 @@ defmodule AcqdatCore.IotManager.DataDump.Worker do
   defp log_data(error, params) do
     params = %{data: params.data, error: error, gateway_uuid: params.gateway_uuid}
     changeset = GatewayError.changeset(%GatewayError{}, params)
-    {:ok, data}= Repo.insert(changeset)
+    {:ok, data} = Repo.insert(changeset)
     data
   end
 end

--- a/apps/acqdat_core/lib/acqdat_core/iot-manager/data_dump/worker.ex
+++ b/apps/acqdat_core/lib/acqdat_core/iot-manager/data_dump/worker.ex
@@ -41,6 +41,9 @@ defmodule AcqdatCore.IotManager.DataDump.Worker do
   end
 
   defp log_data(error, params) do
-    %{data: params.data, error: error, gateway_uuid: params.gateway_uuid}
+    params = %{data: params.data, error: error, gateway_uuid: params.gateway_uuid}
+    changeset = GatewayError.changeset(%GatewayError{}, params)
+    {:ok, data}= Repo.insert(changeset)
+    data
   end
 end

--- a/apps/acqdat_core/test/iot-manager/data_dump/worker_test.exs
+++ b/apps/acqdat_core/test/iot-manager/data_dump/worker_test.exs
@@ -39,7 +39,6 @@ defmodule AcqdatCore.IotManager.DataDump.WorkerTest do
       GatewayDataDump.create(dump_params)
 
       assert {:noreply, {:error, result}} = Worker.handle_cast({:data_dump, dump_params}, %{})
-
       assert %{
                inserted_timestamp: ["duplicate data with same timestamp inserted"]
              } == result.error

--- a/apps/acqdat_core/test/iot-manager/data_dump/worker_test.exs
+++ b/apps/acqdat_core/test/iot-manager/data_dump/worker_test.exs
@@ -39,6 +39,7 @@ defmodule AcqdatCore.IotManager.DataDump.WorkerTest do
       GatewayDataDump.create(dump_params)
 
       assert {:noreply, {:error, result}} = Worker.handle_cast({:data_dump, dump_params}, %{})
+
       assert %{
                inserted_timestamp: ["duplicate data with same timestamp inserted"]
              } == result.error


### PR DESCRIPTION
# Why?
The user should be able to see all the errors happening while creating data dumps Error log created if there is an issue with data dump was caught however, was not being stored anywhere. 

## Changes
- Add business logic to push data dumps to DB.
