### PR TITLE
Fix Wrong topic name in MQTT details

### DIFF
--- a/apps/acqdat_api/lib/acqdat_api_web/views/iot-manager/gateway_view.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/views/iot-manager/gateway_view.ex
@@ -236,7 +236,7 @@ defmodule AcqdatApiWeb.IotManager.GatewayView do
     }
   end
 
-   defp selective_rendering(%{channel: "http"} = gateway) do
+  defp selective_rendering(%{channel: "http"} = gateway) do
     %{
       path: create_url("http", gateway),
       access_token: gateway.access_token

--- a/apps/acqdat_api/lib/acqdat_api_web/views/iot-manager/gateway_view.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/views/iot-manager/gateway_view.ex
@@ -97,35 +97,6 @@ defmodule AcqdatApiWeb.IotManager.GatewayView do
     }
   end
 
-  defp selective_rendering(%{channel: "http"} = gateway) do
-    %{
-      path: create_url("http", gateway),
-      access_token: gateway.access_token
-    }
-  end
-
-  defp create_url("http", gateway) do
-    @http_url <>
-      "orgs/" <>
-      "#{gateway.org_id}" <>
-      "/projects/" <> "#{gateway.project.id}" <> "/gateways/" <> "#{gateway.id}" <> "/data_dump"
-  end
-
-  defp create_url("mqtt", gateway) do
-    "org/" <>
-      "#{gateway.uuid}" <>
-      "/project/" <> "#{gateway.project.uuid}" <> "/gateway/" <> "#{gateway.uuid}"
-  end
-
-  defp selective_rendering(%{channel: "mqtt"} = gateway) do
-    %{
-      topic: create_url("mqtt", gateway),
-      client_id: gateway.uuid,
-      username: gateway.uuid,
-      auth_token: gateway.access_token
-    }
-  end
-
   def render("delete.json", %{gateway: gateway}) do
     %{
       type: "Gateway",
@@ -263,5 +234,34 @@ defmodule AcqdatApiWeb.IotManager.GatewayView do
       slug: hits.slug,
       image_url: hits.image_url
     }
+  end
+
+   defp selective_rendering(%{channel: "http"} = gateway) do
+    %{
+      path: create_url("http", gateway),
+      access_token: gateway.access_token
+    }
+  end
+
+  defp selective_rendering(%{channel: "mqtt"} = gateway) do
+    %{
+      topic: create_url("mqtt", gateway),
+      client_id: gateway.uuid,
+      username: gateway.uuid,
+      auth_token: gateway.access_token
+    }
+  end
+
+  defp create_url("http", gateway) do
+    @http_url <>
+      "orgs/" <>
+      "#{gateway.org_id}" <>
+      "/projects/" <> "#{gateway.project.id}" <> "/gateways/" <> "#{gateway.id}" <> "/data_dump"
+  end
+
+  defp create_url("mqtt", gateway) do
+    "org/" <>
+      "#{gateway.org.uuid}" <>
+      "/project/" <> "#{gateway.project.uuid}" <> "/gateway/" <> "#{gateway.uuid}"
   end
 end

--- a/apps/acqdat_api/lib/acqdat_api_web/views/iot-manager/gateway_view.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/views/iot-manager/gateway_view.ex
@@ -248,7 +248,9 @@ defmodule AcqdatApiWeb.IotManager.GatewayView do
       topic: create_url("mqtt", gateway),
       client_id: gateway.uuid,
       username: gateway.uuid,
-      auth_token: gateway.access_token
+      auth_token: gateway.access_token,
+      host: System.fetch_env!("MQTT_EXPOSED_HOSTNAME"),
+      port: System.fetch_env!("MQTT_EXPOSED_PORT")
     }
   end
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -30,9 +30,9 @@ config :acqdat_core, AcqdatCore.Repo,
   database: "acqdat_core_test",
   hostname: System.get_env("DB_HOST", "localhost"),
   pool: Ecto.Adapters.SQL.Sandbox
-
-# queue_target: 1500,
-# queue_interval: 10000
+  # settings to be used if db connections are failing
+  # queue_target: 1500,
+  # queue_interval: 1000
 
 config :tirexs, :uri, System.get_env("ELASTIC_SEARCH_HOST", "http://localhost:9200")
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -30,9 +30,10 @@ config :acqdat_core, AcqdatCore.Repo,
   database: "acqdat_core_test",
   hostname: System.get_env("DB_HOST", "localhost"),
   pool: Ecto.Adapters.SQL.Sandbox
-  # settings to be used if db connections are failing
-  # queue_target: 1500,
-  # queue_interval: 1000
+
+# settings to be used if db connections are failing
+# queue_target: 1500,
+# queue_interval: 1000
 
 config :tirexs, :uri, System.get_env("ELASTIC_SEARCH_HOST", "http://localhost:9200")
 

--- a/env/example.env
+++ b/env/example.env
@@ -21,3 +21,5 @@ export USER_EMAIL=XXXXXXXXXXX
 export USER_PASSWORD=XXXXXXXXXXX
 export REDIS_PORT=redis://localhost:6379/3
 export HTTP_URL=https://datakrewtech.com/iot/
+export MQTT_EXPOSED_PORT=XXXXXXXX
+export MQTT_EXPOSED_HOSTNAME=XXXXXX


### PR DESCRIPTION
# Why?
The topic being returned for a gateway was wrong. It was showing gateway_uuid in place of org_uuid. Also, need to show the `hostname` and `port` settings for a gateway.

## Changes
- Modify gateway show API to return the proper topic.
- Add fields for hostname and port in the show API

## Ops related items:
Add `MQTT_EXPOSED_HOSTNAME` and `MQTT_EXPOSED_PORT` in the env and docker-compose file for the `web` service.