### PR TITLE
Fixed asset metadata value not getting updated

### DIFF
--- a/apps/acqdat_core/lib/acqdat_core/entity-management/schema/asset.ex
+++ b/apps/acqdat_core/lib/acqdat_core/entity-management/schema/asset.ex
@@ -82,7 +82,7 @@ defmodule AcqdatCore.Schema.EntityManagement.Asset do
   @optional_embedded_params ~w(name uuid parameter_uuid sensor_uuid)a
 
   @embedded_metadata_required ~w(name uuid data_type)a
-  @embedded_metadata_optional ~w(unit)a
+  @embedded_metadata_optional ~w(unit value)a
   @permitted_metadata @embedded_metadata_optional ++ @embedded_metadata_required
 
   @permitted_embedded @required_embedded_params ++ @optional_embedded_params


### PR DESCRIPTION
Added the value in the metadata optional field which was earlier not included because of this the value was not getting updated