### PR TITLE
Fixes: Visualisations's Export visual settings + asset_type metadata update

### DIFF
--- a/apps/acqdat_api/lib/acqdat_api/data_insights/visualizations.ex
+++ b/apps/acqdat_api/lib/acqdat_api/data_insights/visualizations.ex
@@ -76,15 +76,16 @@ defmodule AcqdatApi.DataInsights.Visualizations do
     case fetch_widget(visualization) do
       {:ok, widget} ->
         visual_properties =
-          HighCharts.parse_properties(widget.visual_settings)
-          |> update_in(["title", "text"], &(&1 = title))
+          Map.merge(HighCharts.parse_properties(widget.visual_settings), %{
+            "title" => %{"text" => "#{title}"}
+          })
 
         data = %{
           label: title,
           panel_id: panel_id,
           widget_id: widget.id,
           source_app: "data_insights",
-          visual_properties: Map.merge(visual_properties, visualization.visual_settings),
+          visual_properties: Map.merge(visual_properties, visualization.visual_settings || %{}),
           source_metadata: %{
             source_type: "AcqdatApi.DataInsights.Visualizations",
             source_id: visualization.id

--- a/apps/acqdat_api/lib/acqdat_api/data_insights/visualizations.ex
+++ b/apps/acqdat_api/lib/acqdat_api/data_insights/visualizations.ex
@@ -75,14 +75,16 @@ defmodule AcqdatApi.DataInsights.Visualizations do
 
     case fetch_widget(visualization) do
       {:ok, widget} ->
-        visual_properties = HighCharts.parse_properties(widget.visual_settings)
+        visual_properties =
+          HighCharts.parse_properties(widget.visual_settings)
+          |> update_in(["title", "text"], &(&1 = title))
 
         data = %{
           label: title,
           panel_id: panel_id,
           widget_id: widget.id,
           source_app: "data_insights",
-          visual_properties: visual_properties,
+          visual_properties: Map.merge(visual_properties, visualization.visual_settings),
           source_metadata: %{
             source_type: "AcqdatApi.DataInsights.Visualizations",
             source_id: visualization.id

--- a/apps/acqdat_api/lib/acqdat_api_web/controllers/data_insights/visualizations_controller.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/controllers/data_insights/visualizations_controller.ex
@@ -166,7 +166,7 @@ defmodule AcqdatApiWeb.DataInsights.VisualizationsController do
 
           {:error, message} ->
             conn
-            |> send_error(404, message)
+            |> send_error(400, VisualizationsErrorHelper.error_message(:export_error, message))
         end
 
       404 ->

--- a/apps/acqdat_api/lib/acqdat_api_web/views/error_helpers/data_insights/visualizations_error_helper.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/views/error_helpers/data_insights/visualizations_error_helper.ex
@@ -14,4 +14,12 @@ defmodule AcqdatApiWeb.DataInsights.VisualizationsErrorHelper do
       source: nil
     }
   end
+
+  def error_message(:export_error, message) do
+    %{
+      title: "Problem while exporting visualizations",
+      error: message,
+      source: nil
+    }
+  end
 end

--- a/apps/acqdat_api/test/acqdat_api_web/controllers/data_insights/visualizations_controller_test.exs
+++ b/apps/acqdat_api/test/acqdat_api_web/controllers/data_insights/visualizations_controller_test.exs
@@ -477,6 +477,7 @@ defmodule AcqdatApiWeb.DataInsights.VisualizationsControllerTest do
       assert response["source_app"] == "data_insights"
       assert response["panel"]["id"] == panel.id
       assert response["widget_id"] == widget.id
+      assert response["visual_properties"]["title"]["text"] == "exported visualizations 1.1"
     end
 
     test "fails if invalid token in authorization header", %{

--- a/apps/acqdat_api/test/acqdat_api_web/controllers/entity-management/asset_type_controller_test.exs
+++ b/apps/acqdat_api/test/acqdat_api_web/controllers/entity-management/asset_type_controller_test.exs
@@ -148,15 +148,16 @@ defmodule AcqdatApiWeb.EntityManagement.AssetTypeControllerTest do
       assert Map.has_key?(response, "id")
     end
 
-    test "asset type name update fails, if asset is already associated with this asset_type", %{
-      conn: conn,
-      org: org,
-      project: project
-    } do
+    test "asset type name should be updated even, if asset is already associated with this asset_type",
+         %{
+           conn: conn,
+           org: org,
+           project: project
+         } do
       asset = insert(:asset)
 
       data = %{
-        name: "Water Plant"
+        name: "updated Water Plant"
       }
 
       conn =
@@ -166,14 +167,11 @@ defmodule AcqdatApiWeb.EntityManagement.AssetTypeControllerTest do
           data
         )
 
-      response = conn |> json_response(400)
+      response = conn |> json_response(200)
 
-      assert response == %{
-               "detail" => "There are assets associated with this Asset Type",
-               "source" => nil,
-               "status_code" => 400,
-               "title" => "Asset is associated with this asset type"
-             }
+      assert Map.has_key?(response, "name")
+      assert Map.has_key?(response, "id")
+      assert response["name"] == "updated Water Plant"
     end
 
     test "fails if invalid token in authorization header", %{

--- a/apps/acqdat_api/test/acqdat_api_web/controllers/entity-management/asset_type_controller_test.exs
+++ b/apps/acqdat_api/test/acqdat_api_web/controllers/entity-management/asset_type_controller_test.exs
@@ -99,16 +99,14 @@ defmodule AcqdatApiWeb.EntityManagement.AssetTypeControllerTest do
       asset_type = insert(:asset_type)
 
       data = %{
-        asset_type: %{
-          name: "Water Plant",
-          metadata: [
-            %{
-              name: "metdata",
-              data_type: "string",
-              uuid: "test uuid"
-            }
-          ]
-        }
+        name: "Water Plant",
+        metadata: [
+          %{
+            name: "metdata",
+            data_type: "string",
+            uuid: "test uuid"
+          }
+        ]
       }
 
       conn =
@@ -120,7 +118,7 @@ defmodule AcqdatApiWeb.EntityManagement.AssetTypeControllerTest do
       assert Map.has_key?(response, "id")
     end
 
-    test "asset type update fails, if asset is already associated with this asset_type", %{
+    test "update asset_type metadata if the user appends new metadata", %{
       conn: conn,
       org: org,
       project: project
@@ -128,16 +126,37 @@ defmodule AcqdatApiWeb.EntityManagement.AssetTypeControllerTest do
       asset = insert(:asset)
 
       data = %{
-        asset_type: %{
-          name: "Water Plant",
-          metadata: [
-            %{
-              name: "metdata",
-              data_type: "string",
-              uuid: "test uuid"
-            }
-          ]
-        }
+        name: "Water Plant",
+        metadata: [
+          %{
+            name: "metdata",
+            data_type: "string"
+          }
+        ]
+      }
+
+      conn =
+        put(
+          conn,
+          Routes.asset_type_path(conn, :update, org.id, project.id, asset.asset_type_id),
+          data
+        )
+
+      response = conn |> json_response(200)
+
+      assert Map.has_key?(response, "name")
+      assert Map.has_key?(response, "id")
+    end
+
+    test "asset type name update fails, if asset is already associated with this asset_type", %{
+      conn: conn,
+      org: org,
+      project: project
+    } do
+      asset = insert(:asset)
+
+      data = %{
+        name: "Water Plant"
       }
 
       conn =

--- a/apps/acqdat_core/lib/acqdat_core/entity-management/model/asset_type.ex
+++ b/apps/acqdat_core/lib/acqdat_core/entity-management/model/asset_type.ex
@@ -110,9 +110,9 @@ defmodule AcqdatCore.Model.EntityManagement.AssetType do
     end
   end
 
-  def validate_n_append_metadata(asset_type, params) do
+  def validate_n_append_metadata(asset_type, %{"metadata" => metadata} = params) do
     new_metadata_params =
-      Enum.filter(params["metadata"], fn param -> param["id"] == nil && param["uuid"] == nil end)
+      Enum.filter(metadata, fn param -> param["id"] == nil && param["uuid"] == nil end)
 
     if length(new_metadata_params) > 0 do
       params = %{
@@ -130,6 +130,10 @@ defmodule AcqdatCore.Model.EntityManagement.AssetType do
     else
       {:error, "There are assets associated with this Asset Type"}
     end
+  end
+
+  def validate_n_append_metadata(_asset_type, _params) do
+    {:error, "There are assets associated with this Asset Type"}
   end
 
   def delete(asset_type) do

--- a/apps/acqdat_core/lib/acqdat_core/entity-management/model/asset_type.ex
+++ b/apps/acqdat_core/lib/acqdat_core/entity-management/model/asset_type.ex
@@ -118,17 +118,7 @@ defmodule AcqdatCore.Model.EntityManagement.AssetType do
 
       update_asset_type(asset_type, params)
     else
-      if (params["name"] || params["description"]) &&
-           (params["name"] != asset_type.name || params["description"] != asset_type.description) do
-        params = %{
-          "name" => params["name"] || asset_type.name,
-          "description" => params["description"] || asset_type.description
-        }
-
-        update_asset_type(asset_type, params)
-      else
-        {:error, "There are assets associated with this Asset Type"}
-      end
+      {:error, "There are assets associated with this Asset Type"}
     end
   end
 

--- a/apps/acqdat_core/lib/acqdat_core/entity-management/schema/asset_type.ex
+++ b/apps/acqdat_core/lib/acqdat_core/entity-management/schema/asset_type.ex
@@ -87,8 +87,8 @@ defmodule AcqdatCore.Schema.EntityManagement.AssetType do
   def update_changeset(%__MODULE__{} = asset_type, params) do
     asset_type
     |> cast(params, @permitted)
-    |> cast_embed(:parameters, with: &parameters_changeset/2)
-    |> cast_embed(:metadata, with: &metadata_changeset/2)
+    |> cast_embed(:parameters, with: &update_parameters_changeset/2)
+    |> cast_embed(:metadata, with: &update_metadata_changeset/2)
     |> validate_required(@required_params)
     |> common_changeset()
   end
@@ -118,5 +118,25 @@ defmodule AcqdatCore.Schema.EntityManagement.AssetType do
     |> cast(params, @permitted_metadata)
     |> add_uuid()
     |> validate_required(@embedded_metadata_required)
+  end
+
+  defp update_parameters_changeset(schema, params) do
+    schema =
+      schema
+      |> cast(params, @permitted_embedded)
+
+    schema = if params[:uuid] == nil, do: add_uuid(schema), else: schema
+
+    validate_required(schema, @embedded_required_params)
+  end
+
+  defp update_metadata_changeset(schema, params) do
+    schema =
+      schema
+      |> cast(params, @permitted_metadata)
+
+    schema = if params[:uuid] == nil, do: add_uuid(schema), else: schema
+
+    validate_required(schema, @embedded_metadata_required)
   end
 end

--- a/apps/acqdat_core/lib/acqdat_core/widgets/schema/vendors/highcharts.ex
+++ b/apps/acqdat_core/lib/acqdat_core/widgets/schema/vendors/highcharts.ex
@@ -230,6 +230,7 @@ defmodule AcqdatCore.Widgets.Schema.Vendors.HighCharts do
               data_type: :list,
               user_controlled: false,
               properties: %{
+                type: %{data_type: :string, default_value: "", user_controlled: false},
                 alignTricks: %{data_type: :boolean, default_value: true, user_controlled: false},
                 alternateGridColor: %{data_type: :color, default_value: "", user_controlled: true},
                 dateTimeLabelFormats: %{

--- a/apps/acqdat_core/priv/repo/seed/widget.ex
+++ b/apps/acqdat_core/priv/repo/seed/widget.ex
@@ -3,7 +3,7 @@ defmodule AcqdatCore.Seed.Widget do
   Holds seeds for initial widgets.
   """
   alias AcqdatCore.Seed.Widgets.{Line, Area, Pie, Bar, LineTimeseries, AreaTimeseries, GaugeSeries, SolidGauge,
-        StockSingleLine, DynamicCard, ImageCard, StaticCard, BasicColumn, StackedColumn, StockColumn, HeatMap}
+        StockSingleLine, DynamicCard, ImageCard, StaticCard, BasicColumn, StackedColumn, StockColumn, HeatMap, PivotTable}
   alias AcqdatCore.Seed.Helpers.WidgetHelpers
   alias AcqdatCore.Repo
   alias AcqdatCore.Model.Widgets.Widget, as: WidgetModel
@@ -26,6 +26,7 @@ defmodule AcqdatCore.Seed.Widget do
     StackedColumn.seed()
     StockColumn.seed()
     HeatMap.seed()
+    PivotTable.seed()
     WidgetHelpers.seed_in_elastic()
   end
 

--- a/apps/acqdat_core/test/entity-management/model/asset_type_test.exs
+++ b/apps/acqdat_core/test/entity-management/model/asset_type_test.exs
@@ -1,0 +1,135 @@
+defmodule AcqdatCore.Model.EntityManagement.AssetTypeTest do
+  use ExUnit.Case, async: true
+  use AcqdatCore.DataCase
+  import AcqdatCore.Support.Factory
+  alias AcqdatCore.Model.EntityManagement.AssetType
+
+  describe "update/2" do
+    setup do
+      asset = insert(:asset)
+
+      asset_type = insert(:asset_type)
+
+      [asset: asset, asset_type: asset_type]
+    end
+
+    test "updates asset_type details which does not have any asset attached to it", context do
+      %{asset_type: asset_type} = context
+
+      params = %{
+        name: "updated asset type name",
+        description: "description",
+        metadata: [
+          %{
+            data_type: "string",
+            name: "no of floors"
+          }
+        ]
+      }
+
+      assert {:ok, asset_type} = AssetType.update(asset_type, params)
+      assert asset_type.name == "updated asset type name"
+      assert asset_type.description == "description"
+    end
+
+    test "updates asset_type(connected to assets) params except metadata", context do
+      %{asset: asset} = context
+
+      {:ok, asset_type} = AssetType.get(asset.asset_type_id)
+
+      params = %{
+        name: "updated asset type name",
+        description: "description"
+      }
+
+      assert {:ok, updated_asset_type} = AssetType.update(asset_type, params)
+      assert updated_asset_type.name == "updated asset type name"
+      assert updated_asset_type.description == "description"
+      assert updated_asset_type.metadata == asset_type.metadata
+    end
+
+    test "cannot update asset_type(attached to assets)'s' existing metadata", context do
+      %{asset: asset} = context
+
+      {:ok, asset_type} = AssetType.get(asset.asset_type_id)
+
+      metadata =
+        Enum.reduce(asset_type.metadata, [], fn metadata, acc ->
+          acc ++
+            [
+              %{
+                "name" => "updated metadata name",
+                "data_type" => metadata.data_type,
+                "unit" => metadata.unit,
+                "id" => metadata.id,
+                "uuid" => metadata.uuid
+              }
+            ]
+        end)
+
+      params = %{
+        "name" => "updated asset type name",
+        "description" => "description",
+        "metadata" => metadata
+      }
+
+      assert {:error, error_msg} = AssetType.update(asset_type, params)
+      assert error_msg == "There are assets associated with this Asset Type"
+    end
+
+    test "cannot delete asset_type(attached to assets)'s existing metadata", context do
+      %{asset: asset} = context
+
+      {:ok, asset_type} = AssetType.get(asset.asset_type_id)
+
+      metadata =
+        Enum.reduce(asset_type.metadata, [], fn metadata, _acc ->
+          [
+            %{
+              "name" => "updated metadata name",
+              "data_type" => metadata.data_type,
+              "unit" => metadata.unit,
+              "id" => metadata.id,
+              "uuid" => metadata.uuid
+            }
+          ]
+        end)
+
+      params = %{
+        "name" => "updated asset type name",
+        "description" => "description",
+        "metadata" => metadata
+      }
+
+      assert {:error, error_msg} = AssetType.update(asset_type, params)
+      assert error_msg == "There are assets associated with this Asset Type"
+    end
+
+    test "can append new metadata to asset_type(attached to assets)'s existing metadata",
+         context do
+      %{asset: asset} = context
+
+      {:ok, asset_type} = AssetType.get(asset.asset_type_id)
+
+      metadata = [
+        %{
+          "name" => "new metadata name",
+          "data_type" => "string",
+          "unit" => ""
+        }
+      ]
+
+      params = %{
+        "name" => "updated asset type name",
+        "description" => "description",
+        "metadata" => metadata
+      }
+
+      assert {:ok, updated_asset_type} = AssetType.update(asset_type, params)
+
+      assert updated_asset_type.name == "updated asset type name"
+      assert updated_asset_type.description == "description"
+      assert length(updated_asset_type.metadata) == length(asset_type.metadata) + 1
+    end
+  end
+end

--- a/apps/acqdat_core/test/support/factory/factory.ex
+++ b/apps/acqdat_core/test/support/factory/factory.ex
@@ -253,24 +253,28 @@ defmodule AcqdatCore.Support.Factory do
         %{
           name: sequence(:asset_type_name, &"AssetTypeParam#{&1}"),
           data_type: sequence(:asset_type_name, &"AssetTypeDataType#{&1}"),
-          unit: sequence(:asset_type_name, &"AssetTypeUnit#{&1}")
+          unit: sequence(:asset_type_name, &"AssetTypeUnit#{&1}"),
+          uuid: UUID.uuid1(:hex)
         },
         %{
           name: sequence(:asset_type_name, &"AssetTypeParam#{&1}"),
           data_type: sequence(:asset_type_name, &"AssetTypeDataType#{&1}"),
-          unit: sequence(:asset_type_name, &"AssetTypeUnit#{&1}")
+          unit: sequence(:asset_type_name, &"AssetTypeUnit#{&1}"),
+          uuid: UUID.uuid1(:hex)
         }
       ],
       metadata: [
         %{
           name: sequence(:asset_type_name, &"AssetTypeParam#{&1}"),
           data_type: sequence(:asset_type_name, &"AssetTypeDataType#{&1}"),
-          unit: sequence(:asset_type_name, &"AssetTypeUnit#{&1}")
+          unit: sequence(:asset_type_name, &"AssetTypeUnit#{&1}"),
+          uuid: UUID.uuid1(:hex)
         },
         %{
           name: sequence(:asset_type_name, &"AssetTypeParam#{&1}"),
           data_type: sequence(:asset_type_name, &"AssetTypeDataType#{&1}"),
-          unit: sequence(:asset_type_name, &"AssetTypeUnit#{&1}")
+          unit: sequence(:asset_type_name, &"AssetTypeUnit#{&1}"),
+          uuid: UUID.uuid1(:hex)
         }
       ]
     }


### PR DESCRIPTION
**Changes**
- Added functionality to export visualizations visual_settings to dashboard
- Visualization export test cases fixes
- In case of AssetType attached to asset, newly added Metadata should be appended, but existing metadata should not be updated or deleted
- In case of AssetType attached to asset, name/description can be updated