### PR TITLE
[Role manager]Fixes related to forgot password + minor changes

### DIFF
--- a/apps/acqdat_api/lib/acqdat_api/account.ex
+++ b/apps/acqdat_api/lib/acqdat_api/account.ex
@@ -135,7 +135,13 @@ defmodule AcqdatApi.Account do
         :refresh
       )
 
-    {:ok, %{access_token: access_token, user_id: user.id, refresh_token: refresh_token}}
+    {:ok,
+     %{
+       access_token: access_token,
+       user_id: user.id,
+       org_id: user.org_id,
+       refresh_token: refresh_token
+     }}
   end
 
   defp verify_account({:error, _message}) do

--- a/apps/acqdat_api/lib/acqdat_api_web/views/auth_view.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/views/auth_view.ex
@@ -16,7 +16,8 @@ defmodule AcqdatApiWeb.AuthView do
     %{
       access_token: manifest.access_token,
       refresh_token: manifest.refresh_token,
-      user_id: manifest.user_id
+      user_id: manifest.user_id,
+      org_id: manifest.org_id
     }
   end
 

--- a/apps/acqdat_api/lib/acqdat_api_web/views/entity-management/organisation_view.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/views/entity-management/organisation_view.ex
@@ -22,7 +22,8 @@ defmodule AcqdatApiWeb.EntityManagement.OrganisationView do
       url: org.url,
       name: org.name,
       uuid: org.uuid,
-      avatar: org.avatar
+      avatar: org.avatar,
+      description: org.description
     }
   end
 
@@ -51,6 +52,7 @@ defmodule AcqdatApiWeb.EntityManagement.OrganisationView do
       id: organisation.id,
       name: organisation.name,
       url: organisation.url,
+      description: organisation.description,
       apps: render_many(organisation.apps, AppView, "app.json"),
       org_admin: render_many(org_admin, OrganisationView, "admin.json")
     }

--- a/apps/acqdat_api/lib/acqdat_api_web/views/role-management/user_view.ex
+++ b/apps/acqdat_api/lib/acqdat_api_web/views/role-management/user_view.ex
@@ -30,6 +30,7 @@ defmodule AcqdatApiWeb.RoleManagement.UserView do
       avatar: user_credentials.avatar,
       user_credentials_id: user_credentials.id,
       metadata: user_credentials.metadata && Map.from_struct(user_credentials.metadata),
+      user_credentials: render_one(user_credentials, UserView, "user_credentials.json"),
       role: render_one(preload_role(user_details.role_id), RoleView, "role.json"),
       org:
         render_one(

--- a/apps/acqdat_api/test/acqdat_api_web/controllers/elasticsearch/user_controller_test.exs
+++ b/apps/acqdat_api/test/acqdat_api_web/controllers/elasticsearch/user_controller_test.exs
@@ -21,7 +21,7 @@ defmodule AcqdatApiWeb.ElasticSearch.UserControllerTest do
       [new_user: user]
     end
 
-    test "fails if authorization header not found", %{conn: conn, user: user} do
+    test "fails if authorization header not found", %{conn: conn} do
       bad_access_token = "avcbd123489u"
       org = insert(:organisation)
 
@@ -63,6 +63,7 @@ defmodule AcqdatApiWeb.ElasticSearch.UserControllerTest do
         "name" => user.org.name,
         "type" => "Organisation",
         "uuid" => user.org.uuid,
+        "description" => user.org.description,
         "url" => nil,
         "avatar" => nil
       }
@@ -154,8 +155,7 @@ defmodule AcqdatApiWeb.ElasticSearch.UserControllerTest do
       conn: conn,
       user1: user1,
       user2: user2,
-      user3: user3,
-      new_org: org
+      user3: user3
     } do
       conn =
         get(conn, Routes.user_path(conn, :index, user1.org_id), %{

--- a/apps/acqdat_api/test/acqdat_api_web/controllers/entity-management/organisation_controller_test.exs
+++ b/apps/acqdat_api/test/acqdat_api_web/controllers/entity-management/organisation_controller_test.exs
@@ -59,6 +59,7 @@ defmodule AcqdatApiWeb.EntityManagement.OrganisationControllerTest do
                "name" => org.name,
                "type" => "Organisation",
                "uuid" => org.uuid,
+               "description" => org.description,
                "url" => nil
              }
     end

--- a/apps/acqdat_core/lib/acqdat_core/role-management/model/forgot_password.ex
+++ b/apps/acqdat_core/lib/acqdat_core/role-management/model/forgot_password.ex
@@ -21,14 +21,14 @@ defmodule AcqdatCore.Model.RoleManagement.ForgotPassword do
         {:error, "Token is invalid"}
 
       details ->
-        UserCredentials.get(details.user_id)
+        UserCredentials.get(details.user_credentials_id)
     end
   end
 
-  def delete(user_id) do
+  def delete(user_credentials_id) do
     query =
       from(details in ForgotPassword,
-        where: details.user_id == ^user_id
+        where: details.user_credentials_id == ^user_credentials_id
       )
 
     Repo.delete(List.first(Repo.all(query)))

--- a/apps/acqdat_core/lib/acqdat_core/role-management/model/user.ex
+++ b/apps/acqdat_core/lib/acqdat_core/role-management/model/user.ex
@@ -31,7 +31,7 @@ defmodule AcqdatCore.Model.RoleManagement.User do
   @doc """
   Returns a user by the supplied id.
   """
-  def get(id) when is_integer(id) do
+  def get(id) do
     case Repo.get(User, id) |> Repo.preload([:user_credentials]) do
       nil ->
         {:error, "not found"}

--- a/apps/acqdat_core/lib/acqdat_core/role-management/model/user.ex
+++ b/apps/acqdat_core/lib/acqdat_core/role-management/model/user.ex
@@ -228,6 +228,21 @@ defmodule AcqdatCore.Model.RoleManagement.User do
     |> Repo.preload([:user_credentials, :org, :role, user_group: :user_group, policies: :policy])
   end
 
+  def active_user(email) do
+    query =
+      from(
+        user in User,
+        join: cred in UserCredentials,
+        on:
+          cred.id == user.user_credentials_id and cred.email == ^email and
+            user.is_deleted == false,
+        group_by: cred.id,
+        select: cred
+      )
+
+    Repo.one(query)
+  end
+
   def fetch_user_orgs_by_email(email) do
     query =
       from(

--- a/apps/acqdat_core/lib/acqdat_core/role-management/schema/forgot_password.ex
+++ b/apps/acqdat_core/lib/acqdat_core/role-management/schema/forgot_password.ex
@@ -1,21 +1,21 @@
 defmodule AcqdatCore.Schema.RoleManagement.ForgotPassword do
   @moduledoc """
-  Models a table which contains details related to user and their respective token which will be accessed at the time of resetting password
+  Models a table which contains details related to user_credentials and their respective token which will be accessed at the time of resetting password
   """
 
   use AcqdatCore.Schema
-  alias AcqdatCore.Schema.RoleManagement.{User}
+  alias AcqdatCore.Schema.RoleManagement.UserCredentials
 
   @type t :: %__MODULE__{}
 
   schema "acqdat_recovery_details" do
     # associations
     field(:token, :string, null: false)
-    belongs_to(:user, User)
+    belongs_to(:user_credentials, UserCredentials)
     timestamps(type: :utc_datetime)
   end
 
-  @required_params ~w(user_id token)a
+  @required_params ~w(user_credentials_id token)a
 
   @spec changeset(t, map) :: Ecto.Changeset.t()
   def changeset(%__MODULE__{} = forgot_password, params) do
@@ -31,7 +31,7 @@ defmodule AcqdatCore.Schema.RoleManagement.ForgotPassword do
     forgot_password
     |> cast(params, @required_params)
     |> validate_required(@required_params)
-    |> foreign_key_constraint(:user_id)
+    |> foreign_key_constraint(:user_credentials_id)
     |> unique_constraint(:token, name: :unique_token_per_user)
   end
 end

--- a/apps/acqdat_core/priv/repo/migrations/20210730071737_add_user_credentials_assoc_to_recovery_details.exs
+++ b/apps/acqdat_core/priv/repo/migrations/20210730071737_add_user_credentials_assoc_to_recovery_details.exs
@@ -1,0 +1,10 @@
+defmodule AcqdatCore.Repo.Migrations.AddUserCredentialsAssocToRecoveryDetails do
+  use Ecto.Migration
+
+  def change do
+    alter table("acqdat_recovery_details") do
+      add(:user_credentials_id, references("acqdat_user_credentials"), on_delete: :delete_all)
+      remove(:user_id)
+    end
+  end
+end


### PR DESCRIPTION
**Changes**
- Added migration to associate user_credentials to recovery_details table instead of user_id
- Fixed forgot password flow, recovery_details table was getting attached to user_id but it should be attached to user_credentials_id
- Preloaded user_credentials info in the user show api
- Added description to all the org related apis
- Added org_id to org_sign_in api response