### PR TITLE
feat(stream): Adds Init action schema and tests

### DIFF
--- a/apps/acqdat_core/lib/acqdat_core/streams/schema/init.ex
+++ b/apps/acqdat_core/lib/acqdat_core/streams/schema/init.ex
@@ -1,0 +1,23 @@
+defmodule AcqdatCore.Schema.Streams.Init do
+  @moduledoc """
+  The root action for all telemetry pipelines.
+  """
+  use AcqdatCore.Schema
+
+  @typedoc """
+  Currently this type has no fields.
+  """
+  @type t :: %__MODULE__{}
+
+  @primary_key false
+  embedded_schema do
+  end
+
+  @doc """
+  Changeset for creating `init` action.
+  """
+  @spec changeset(t | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()
+  def changeset(init, _) do
+    cast(init, %{}, [])
+  end
+end

--- a/apps/acqdat_core/priv/repo/migrations/20211120193236_constraint_one_init_per_pipeline.exs
+++ b/apps/acqdat_core/priv/repo/migrations/20211120193236_constraint_one_init_per_pipeline.exs
@@ -1,0 +1,7 @@
+defmodule AcqdatCore.Repo.Migrations.ConstraintOneInitPerPipeline do
+  use Ecto.Migration
+
+  def change do
+    create unique_index("acqdat_streams_actions", [:type, :pipeline_id], name: :atmost_one_init_per_pipeline, where: "type = 'init'")
+  end
+end

--- a/apps/acqdat_core/test/streams/schema/action_test.exs
+++ b/apps/acqdat_core/test/streams/schema/action_test.exs
@@ -14,8 +14,7 @@ defmodule AcqdatCore.Schema.Streams.ActionTest do
     test "valid changeset", %{pipeline: pipeline} do
       params = %{
         pipeline_id: pipeline.id,
-        type: :init,
-        config: %{}
+        type: :init
       }
 
       %{valid?: validity} = Action.create_changeset(%Action{}, params)

--- a/apps/acqdat_core/test/streams/schema/init_test.exs
+++ b/apps/acqdat_core/test/streams/schema/init_test.exs
@@ -1,0 +1,42 @@
+defmodule AcqdatCore.Schema.Streams.InitTest do
+  use ExUnit.Case, async: true
+  use AcqdatCore.DataCase
+
+  import AcqdatCore.Support.Factory
+
+  alias AcqdatCore.Schema.Streams.{Init, Action}
+
+  describe "create changeset/2" do
+    setup do
+      [pipeline: insert(:pipeline)]
+    end
+
+    test "valid changeset", %{pipeline: pipeline} do
+      params = %{
+        pipeline_id: pipeline.id,
+        name: "my-init",
+        type: :init
+      }
+
+      %{valid?: validity} = Action.create_changeset(%Action{}, params)
+      assert validity
+    end
+
+    test "only one init per pipeline", %{pipeline: pipeline} do
+      params = %{
+        pipeline_id: pipeline.id,
+        name: "my-init",
+        type: :init,
+        config: %{foo: :bar}
+      }
+
+      {:ok, init} = Repo.insert(Action.create_changeset(%Action{}, params))
+      assert init.config == %Init{}
+      {:error, changeset} = Repo.insert(Action.create_changeset(%Action{}, params))
+
+      assert %{
+               type: ["pipeline already has `init` action"]
+             } = errors_on(changeset)
+    end
+  end
+end


### PR DESCRIPTION
Init
===
Just 2 columns, `:id` and `:type` for the super/sub type relation. There are no configurable params.
Cardinality of these actions is constrained with a partial index on `Action`, forcing at most one Init per pipeline.

To create Init, build an `Action` changeset with `type: :init`.