### PR TITLE
Fix/alert grouping

### DIFF
--- a/apps/acqdat_core/lib/acqdat_core/alerts/alert_creation/alert_creation.ex
+++ b/apps/acqdat_core/lib/acqdat_core/alerts/alert_creation/alert_creation.ex
@@ -162,7 +162,7 @@ defmodule AcqdatCore.Alerts.AlertCreation do
         rule_uuid: alert_rule.uuid,
         parameter_uuid: parameter.uuid
       },
-      grouping_meta: alert_rule.grouping_meta,
+      grouping_meta: Map.from_struct(alert_rule.grouping_meta),
       org_id: alert_rule.org_id,
       project_id: alert_rule.project_id,
       recipient_ids: format_recipient_ids(alert_rule.recepient_ids),

--- a/apps/acqdat_core/lib/acqdat_core/alerts/model/grouping.ex
+++ b/apps/acqdat_core/lib/acqdat_core/alerts/model/grouping.ex
@@ -160,7 +160,7 @@ defmodule AcqdatCore.Alerts.Model.Grouping do
   # TODO: optimize creating grouping_meta
   defp prepare_insert_params(%Token{} = params, grouping_hash) do
     grouping_params =
-      Map.put(params.grouping_meta.grouping_parameters, :previous_time, params.inserted_timestamp)
+      Map.put(params.grouping_meta.grouping_parameters, "previous_time", params.inserted_timestamp)
 
     grouping_meta = Map.put(params.grouping_meta, :grouping_parameters, grouping_params)
 

--- a/apps/acqdat_core/lib/acqdat_core/alerts/model/grouping.ex
+++ b/apps/acqdat_core/lib/acqdat_core/alerts/model/grouping.ex
@@ -160,7 +160,10 @@ defmodule AcqdatCore.Alerts.Model.Grouping do
   # TODO: optimize creating grouping_meta
   defp prepare_insert_params(%Token{} = params, grouping_hash) do
     grouping_params =
-      Map.put(params.grouping_meta.grouping_parameters, "previous_time", params.inserted_timestamp)
+      case Map.has_key?(params.grouping_meta.grouping_parameters, :unit) do
+        true -> Map.put(params.grouping_meta.grouping_parameters, :previous_time, params.inserted_timestamp)
+        false -> Map.put(params.grouping_meta.grouping_parameters, "previous_time", params.inserted_timestamp)
+      end
 
     grouping_meta = Map.put(params.grouping_meta, :grouping_parameters, grouping_params)
 


### PR DESCRIPTION
1. Modified logic for alert grouping since a struct was getting passed so converted it to Map and an atom key is being used along with string hence type mismatch was happening
2. Added support for key type check